### PR TITLE
Fix/import specific items

### DIFF
--- a/src/components/codebeamer.ts
+++ b/src/components/codebeamer.ts
@@ -100,6 +100,10 @@ async function getCodeBeamerWiki2Html(markup, trackerItem) {
     body: JSON.stringify(body),
   })
     .then(res => res.text())
+    .catch(err => {
+      console.warn(`Failed converting ${trackerItem.id}'s description to HTML. It might therefore look a little weird. This is a known issue, which is being worked on.`)
+      return markup;
+    })
 }
 
 /**
@@ -188,13 +192,16 @@ async function addNewCbItem(item: CreateCbItem) {
 
 async function enrichBaseCbItemWithDetails(cbItem) {
   cbItem.tracker = await getCodeBeamerTrackerDetails(cbItem.tracker)
-  cbItem.renderedDescription =
-    cbItem.description
-      ? (cbItem.descriptionFormat === 'Wiki'
-        ? await getCodeBeamerWiki2Html(cbItem.description, cbItem)
-        : cbItem.description)
-      : ""
-  return cbItem
+  
+  cbItem.renderedDescription = "";
+  if(cbItem.description)
+      if(cbItem.descriptionFormat === 'Wiki'){
+        cbItem.renderedDescription = await getCodeBeamerWiki2Html(cbItem.description, cbItem);
+      } else
+      { 
+        cbItem.renderedDescription = cbItem.description;
+      }
+  return cbItem;
 }
 
 export async function createOrUpdateCbItem(cbItem) {


### PR DESCRIPTION
For those that have access, **RETINA-287260** is the issue regarding the underlying bug.

This MR hotfixes this bug and should therefore allow also importing items that previously failed due to a `CONTENT_LENGTH_MISMATCH` error following the `wiki2Html` request's termination.

The requests in this case will still take as long as they did (since that problem originates from Retina), and the user will only see an indeterminate progress circle. But when we catch the error (after usually ~1min), the item's description will default to the raw markup and be created.