### PR TITLE
Fix/wiki description break

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "AGPL-3.0",
       "dependencies": {
+        "html-entities": "^2.3.2",
         "md5": "^2.3.0",
         "sanitize-html": "^2.5.1"
       },
@@ -1215,6 +1216,11 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/html-entities": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.2.tgz",
+      "integrity": "sha512-c3Ab/url5ksaT0WyleslpBEthOzWhrjQbg75y7XUsfSzi3Dgzt0l8w5e7DylRn15MTlMMD58dTfzddNS2kcAjQ=="
     },
     "node_modules/htmlparser2": {
       "version": "6.1.0",
@@ -3962,6 +3968,11 @@
       "requires": {
         "whatwg-encoding": "^2.0.0"
       }
+    },
+    "html-entities": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.2.tgz",
+      "integrity": "sha512-c3Ab/url5ksaT0WyleslpBEthOzWhrjQbg75y7XUsfSzi3Dgzt0l8w5e7DylRn15MTlMMD58dTfzddNS2kcAjQ=="
     },
     "htmlparser2": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Max Proprawe",
   "name": "codebeamer-miro",
-  "version": "0.0.1",
+  "version": "0.2.28",
   "license": "AGPL-3.0",
   "files": [
     "src/**/*"
@@ -13,7 +13,9 @@
     "build": "webpack",
     "watch": "webpack -w",
     "start": "http-server dist --cors",
-    "ngrok": "ngrok http 8081"
+    "ngrok": "ngrok http 8081",
+    "prepublish:test": "npm run build",
+    "publish:test": "XCOPY dist C:\\users\\urecha\\source\\repos\\urecha.github.io /s /y && CD C:\\users\\urecha\\source\\repos\\urecha.github.io && git add . && git commit -m \"auto-publish to test env\" && git push"
   },
   "devDependencies": {
     "http-server": "^14.1.0",
@@ -34,7 +36,7 @@
   },
   "homepage": "https://github.com/max-poprawe/codebeamer-miro#readme",
   "dependencies": {
-    "md5": "^2.3.0",
+    "html-entities": "^2.3.2",
     "sanitize-html": "^2.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Max Proprawe",
   "name": "codebeamer-miro",
-  "version": "0.2.28",
+  "version": "0.2.29",
   "license": "AGPL-3.0",
   "files": [
     "src/**/*"

--- a/package.json
+++ b/package.json
@@ -13,9 +13,7 @@
     "build": "webpack",
     "watch": "webpack -w",
     "start": "http-server dist --cors",
-    "ngrok": "ngrok http 8081",
-    "prepublish:test": "npm run build",
-    "publish:test": "XCOPY dist C:\\users\\urecha\\source\\repos\\urecha.github.io /s /y && CD C:\\users\\urecha\\source\\repos\\urecha.github.io && git add . && git commit -m \"auto-publish to test env\" && git push"
+    "ngrok": "ngrok http 8081"
   },
   "devDependencies": {
     "http-server": "^14.1.0",

--- a/src/components/codebeamer.ts
+++ b/src/components/codebeamer.ts
@@ -3,6 +3,7 @@ import { convert2CbItem, convert2Card, CreateCbItem } from "./converter";
 import Store from './store';
 import { BoardSetting, Constants, LocalSetting, SessionSetting } from "./constants";
 import * as sanitizeHtml from 'sanitize-html';
+import { encode }from 'html-entities';
 
 const store = Store.getInstance();
 
@@ -88,6 +89,8 @@ async function getCodeBeamerItemDetails(item) {
 }
 
 async function getCodeBeamerWiki2Html(markup, trackerItem) {
+  markup = encodeSpecialChars(markup);
+
   let body = {
     contextId: trackerItem.id,
     contextVersion: trackerItem.version,
@@ -104,6 +107,15 @@ async function getCodeBeamerWiki2Html(markup, trackerItem) {
       console.warn(`Failed converting ${trackerItem.id}'s description to HTML. It might therefore look a little weird. This is a known issue, which is being worked on.`)
       return markup;
     })
+}
+
+/**
+ * Encodes potential special chars, which codebeamer can't deal with very well.
+ * @param markup Text to cleanse
+ * @returns Input with encoded special characters.
+ */
+function encodeSpecialChars(markup: string): string {
+  return encode(markup, { mode: 'extensive' });
 }
 
 /**

--- a/src/components/codebeamer.ts
+++ b/src/components/codebeamer.ts
@@ -112,10 +112,17 @@ async function getCodeBeamerWiki2Html(markup, trackerItem) {
 /**
  * Encodes potential special chars, which codebeamer can't deal with very well.
  * @param markup Text to cleanse
- * @returns Input with encoded special characters.
+ * @returns Input with encoded special characters, processable by cb's /wiki2Html endpoint
  */
 function encodeSpecialChars(markup: string): string {
-  return encode(markup, { mode: 'extensive' });
+  //only "extensive" mode cleanses all special chars which codeBeamer seems to have troubles with
+  markup = encode(markup, { mode: 'extensive' });
+
+  //return some specific cb wiki markup chars to their original form, or codeBeamer won't be able to recognize them as wiki-markup to be converted to html and the whole call becomes redundant
+  markup = markup.replace(/&percnt;/g, "%").replace(/&excl;/g, "!").replace(/&semi;/g, ";").replace(/&colon;/g, ":").replace("/&comma;/g", ",").replace(/&lpar;/g, "(").replace(/&rpar;/g, ")");
+
+  return markup;
+
 }
 
 /**

--- a/src/components/converter.ts
+++ b/src/components/converter.ts
@@ -6,7 +6,6 @@ import Store from './store'
 import { UserMapping } from '../types/UserMapping';
 
 export async function convert2Card(item): Promise<CardData> {
-  console.log("Converting to card: ", item);
   let cardData: CardData = {
     type: 'CARD',
     title: `<a href="${getCodeBeamerItemURL(item.id)}">[${item.tracker.keyName}-${item.id}] - ${item.name}</a>`,

--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <!--sync version number with console log in init.ts-->
-  <title>CB-Miro v0.2.28</title>
+  <title>CB-Miro v0.2.29</title>
   <link type="stylesheet" href="styles/index.css">
   <style>
     body {
@@ -43,7 +43,7 @@
     <img src="img/miro-Logo.png"/>
   </div>
   <h3>
-    codeBeamer synchronizer plugin for Miro
+    codeBeamer synchronizer plugin for Miro v0.2.29
     <br>
       by 
       <a href="https://github.com/max-poprawe">max-poprawe</a>, 

--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <!--sync version number with console log in init.ts-->
-  <title>CB-Miro v0.2.26</title>
+  <title>CB-Miro v0.2.28</title>
   <link type="stylesheet" href="styles/index.css">
   <style>
     body {

--- a/src/init.ts
+++ b/src/init.ts
@@ -26,7 +26,7 @@ miro.onReady(() => {
           getCodeBeamerUser()
             .then(() => miro.board.ui.openModal('picker.html'))
             .catch(err => {
-              miro.showErrorNotification(`Please fix CB Connection settings. CB Connection could not be established: ${err}`)
+              miro.showErrorNotification(`CodeBeamer connection could not be established. Please fix the Connection settings.`)
               miro.board.ui.openModal('settings.html')
             })
         },
@@ -60,7 +60,7 @@ miro.onReady(() => {
       },
     }
   });
-  console.log(`[codeBeamer-sync] Plugin v0.2.28 initialized. Experiencing issues? Let us know under https://github.com/max-poprawe/codebeamer-miro`)
+  console.log(`[codeBeamer-sync] Plugin v0.2.29 initialized. Experiencing issues? Let us know at https://github.com/codeBeamer-Extensions-and-Addons/codebeamer-miro/issues`)
   miro.isAuthorized().then((isAuthorized) => {
     if(!isAuthorized) {
       miro.requestAuthorization();

--- a/src/init.ts
+++ b/src/init.ts
@@ -60,7 +60,7 @@ miro.onReady(() => {
       },
     }
   });
-  console.log(`[codeBeamer-sync] Plugin v0.2.26 initialized. Experiencing issues? Let us know under https://github.com/max-poprawe/codebeamer-miro`)
+  console.log(`[codeBeamer-sync] Plugin v0.2.28 initialized. Experiencing issues? Let us know under https://github.com/max-poprawe/codebeamer-miro`)
   miro.isAuthorized().then((isAuthorized) => {
     if(!isAuthorized) {
       miro.requestAuthorization();

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,11 +7,9 @@ export function syncWithCodeBeamer(itemIds : string[]) {
   return getCodeBeamerCbqlResult(`item.id IN (${itemIds.join(',')})`)
     .then(async queryResult => queryResult.items)
     .then(async cbItems => {
-      console.log('starting createOrUpdateCbItem for all Items')
       for (let cbItem of cbItems) {
         await createOrUpdateCbItem(cbItem)
       }
-      console.log('starting createUpdateOrDeleteRelationLines for all Items')
       for (let cbItem of cbItems) {
         await createUpdateOrDeleteRelationLines(cbItem)
       }


### PR DESCRIPTION
Updates the client to modify the text it would send to /wiki2html in a way that makes the endpoint not take a minute per request.

- utilize npm pkg to cleanse text before sending it to /wiki2html
makes it as fast as without special chars.
- manually decoding specific cb wiki markup chars then gets the desired result  
(although the testing suite wasn't that extensive.)
