### PR TITLE
Ipa/feature/improve results ux 1565419

### DIFF
--- a/cypress/integration/picker.spec.ts
+++ b/cypress/integration/picker.spec.ts
@@ -32,11 +32,17 @@ describe('Picker', () => {
     
         it('has an update button', () => {
             cy.get('button#synchButton');
-        });   
-
-        it('displays two pagination controls for the data table', () => {
-            cy.get('div#dataTable-controls').find('button').should('have.length', 2);
+        }); 
+        
+        //* RETINA-1565419
+        it.only('has a button to load more search results with', () => {
+            cy.get('#lazy-load-button');
         });
+        
+        //* RETINA-1565419
+        it.only('disables the button to load more search results with by default', () => {
+            cy.get('lazy-load-buzzon').should('have.attr', 'disabled');
+        })
 
         it.skip('shows the Tracker Select by default', () => {
             cy.get('div#simpleSearch').should('have.class', 'visible');
@@ -48,12 +54,12 @@ describe('Picker', () => {
         context('simple search', () => {
 
             //* RETINA-1565408
-            it.only('displays a secondary filter criteria input in simple search', () => {
+            it('displays a secondary filter criteria input in simple search', () => {
                 cy.get('#simpleSearch').find('#filter').find('input#filter-criteria');
             });
 
             //* RETINA-1565408
-            it.only('allows to choose Team, Release or Subject als secondary filter criteria', () => {
+            it('allows to choose Team, Release or Subject as secondary filter criteria', () => {
                 cy.get('#simpleSearch').find('select').children('option').contains('Team');
                 cy.get('#simpleSearch').find('select').children('option').contains('Release');
                 cy.get('#simpleSearch').find('select').children('option').contains('Subject');
@@ -107,12 +113,6 @@ describe('Picker', () => {
     
             cy.get('div#table-container').should('have.descendants', 'tr').should('have.descendants', 'td');
         });
-
-        it('displays a select-all checkbox to select all items on a table-page when a Tracker is selected', () => {
-            cy.get('select#selectedTracker').select('4877085');
-    
-            cy.get('input#checkAll');
-        });
         
         it('enables the import button when an item is checked', () => {
             cy.get('select#selectedTracker').select('4877085');
@@ -135,7 +135,7 @@ describe('Picker', () => {
         describe('simple search', () => {
 
             //* RETINA-1565408
-            it.only('filters the result table by the secondary criteria when it\'s updated', () => {                
+            it('filters the result table by the secondary criteria when it\'s updated', () => {                
                 cy.intercept('POST', 'https://retinatest.roche.com/cb/api/v3/items/query', []).as('query')
 
                 cy.get('select#selectedTracker').select('4877085');
@@ -145,7 +145,25 @@ describe('Picker', () => {
                     assert.isArray(interception.response?.body);
                 })
             });
-        })
+        });
+
+        //* RETINA-1565419
+        describe('loading additional results', () => {
+
+            it.only('loads additional search results when clicking the "load more results" button and appends them to the results table', () => {
+                cy.intercept('POST', 'https://retinatest.roche.com/cb/api/v3/items/query', { fixture: 'trackerItems_page2.json'}).as('query')
+
+                cy.get('select#selectedTracker').select('4877085');
+                cy.get('#lazy-load-button').click();
+
+                //expect it to be called
+                cy.wait('@query');
+
+                //expect this element to have been appended to the table
+                cy.get('input#1431175');
+            })
+
+        });
 
     });
 

--- a/cypress/integration/picker.spec.ts
+++ b/cypress/integration/picker.spec.ts
@@ -41,7 +41,7 @@ describe('Picker', () => {
         
         //* RETINA-1565419
         it.only('disables the button to load more search results with by default', () => {
-            cy.get('lazy-load-buzzon').should('have.attr', 'disabled');
+            cy.get('#lazy-load-button').should('have.attr', 'disabled');
         })
 
         it.skip('shows the Tracker Select by default', () => {
@@ -133,7 +133,7 @@ describe('Picker', () => {
         });
 
         describe('simple search', () => {
-
+            
             //* RETINA-1565408
             it('filters the result table by the secondary criteria when it\'s updated', () => {                
                 cy.intercept('POST', 'https://retinatest.roche.com/cb/api/v3/items/query', []).as('query')
@@ -147,10 +147,15 @@ describe('Picker', () => {
             });
         });
 
-        //* RETINA-1565419
         describe('loading additional results', () => {
 
-            it.only('loads additional search results when clicking the "load more results" button and appends them to the results table', () => {
+            //* RETINA-1565419
+            it('enables the "load more results" button when there are more items that can be loaded for the selected criteria', () => {
+                cy.get('#lazy-load-button').should('not.have.attr', 'disabled');
+            });
+
+            //* RETINA-1565419
+            it('loads additional search results when clicking the "load more results" button and appends them to the results table', () => {
                 cy.intercept('POST', 'https://retinatest.roche.com/cb/api/v3/items/query', { fixture: 'trackerItems_page2.json'}).as('query')
 
                 cy.get('select#selectedTracker').select('4877085');

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Max Poprawe",
   "name": "codebeamer-miro",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "license": "AGPL-3.0",
   "files": [
     "src/**/*"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Max Poprawe",
   "name": "codebeamer-miro",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "license": "AGPL-3.0",
   "files": [
     "src/**/*"

--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <!--sync version number with console log in init.ts-->
-  <title>CB-Miro v0.6.0</title>
+  <title>CB-Miro v0.6.1</title>
   <link type="stylesheet" href="styles/index.css">
   <style>
     body {
@@ -43,7 +43,7 @@
     <img src="img/miro-Logo.png"/>
   </div>
   <h3>
-    codeBeamer synchronizer plugin for Miro v0.6.0
+    codeBeamer synchronizer plugin for Miro v0.6.1
     <br>
       by 
       <a href="https://github.com/max-poprawe">max-poprawe</a>, 

--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <!--sync version number with console log in init.ts-->
-  <title>CB-Miro v0.5.1</title>
+  <title>CB-Miro v0.6.0</title>
   <link type="stylesheet" href="styles/index.css">
   <style>
     body {
@@ -43,7 +43,7 @@
     <img src="img/miro-Logo.png"/>
   </div>
   <h3>
-    codeBeamer synchronizer plugin for Miro v0.5.1
+    codeBeamer synchronizer plugin for Miro v0.6.0
     <br>
       by 
       <a href="https://github.com/max-poprawe">max-poprawe</a>, 

--- a/src/init.ts
+++ b/src/init.ts
@@ -77,7 +77,7 @@ miro.onReady(async () => {
 	});
 
 	console.info(
-		`[codeBeamer-sync] Plugin v0.5.1 initialized. Experiencing issues? Let us know at https://github.com/codeBeamer-Extensions-and-Addons/codebeamer-miro/issues`
+		`[codeBeamer-sync] Plugin v0.6.0 initialized. Experiencing issues? Let us know at https://github.com/codeBeamer-Extensions-and-Addons/codebeamer-miro/issues`
 	);
 });
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -77,7 +77,7 @@ miro.onReady(async () => {
 	});
 
 	console.info(
-		`[codeBeamer-sync] Plugin v0.6.0 initialized. Experiencing issues? Let us know at https://github.com/codeBeamer-Extensions-and-Addons/codebeamer-miro/issues`
+		`[codeBeamer-sync] Plugin v0.6.1 initialized. Experiencing issues? Let us know at https://github.com/codeBeamer-Extensions-and-Addons/codebeamer-miro/issues`
 	);
 });
 

--- a/src/pages/picker/picker.css
+++ b/src/pages/picker/picker.css
@@ -14,35 +14,18 @@ body {
 	opacity: 0;
 }
 #table-container {
-	max-height: 60%;
+	position: relative;
+    overflow-y: scroll;
+    max-height: 320px;
 }
-table {
-	margin: 1rem;
-	width: 95%;
-	border-collapse: collapse;
+#table-container #dataTable {
+	border-collapse: separate;
 }
-table th {
-	background-color: var(--miro-blue);
-	color: white;
-	padding: 12px 8px;
-	text-align: left;
-}
-table tr,
-table th {
-	border-bottom: 1px solid lightgray;
-}
-table tr:nth-child(even) {
-	background-color: var(--miro-lightestgray);
-}
-table tr:hover {
-	background-color: var(--miro-lightgray);
-}
-td {
-	padding: 2px;
-	max-width: 100px;
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
+#dataTable thead {
+	position: sticky;
+    top: 0;
+    background: white;
+    z-index: 1;
 }
 #pageLabel {
 	position: relative;
@@ -167,4 +150,20 @@ button svg {
 	to {
 		opacity: 1;
 	}
+}
+
+/**custom scrollbar*/
+::-webkit-scrollbar {
+    width: 10px;
+}
+::-webkit-scrollbar-track {
+    background: #eee;
+    border-radius: 5px;
+}
+::-webkit-scrollbar-thumb {
+    background: var(--miro-blue);
+    border-radius: 5px;
+}
+::-webkit-scrollbar-thumb:hover {
+    background: #455bed;
 }

--- a/src/pages/picker/picker.html
+++ b/src/pages/picker/picker.html
@@ -72,7 +72,12 @@
 
     </div>
     <div id='table-container'>
-      <table id='dataTable'></table>
+      <table id='dataTable' class="table table-sm"></table>
+      <div class="text-center py-1">
+        <button id="lazy-load-button" disabled class="miro-btn miro-btn--secondary miro-btn--small">
+          Load more results
+        </button>
+      </div>
       <div id='loadingSpinner' class="pt-4 loading loading-medium" hidden></div>
     </div>
     <footer>
@@ -85,7 +90,7 @@
         <svg xmlns="http://www.w3.org/2000/svg" class="ionicon" viewBox="0 0 512 512"><path d="M336 176h40a40 40 0 0140 40v208a40 40 0 01-40 40H136a40 40 0 01-40-40V216a40 40 0 0140-40h40" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="32"/><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="32" d="M176 272l80 80 80-80M256 48v288"/></svg>
         <span>
           Import all
-          <img class="hint" src="img/questionMark_white.svg" title="Import all items for the selected tracker">
+          <img class="hint" src="img/questionMark_white.svg" title="Import all items for the selected criteria">
         </span>
       </button>
 
@@ -94,13 +99,6 @@
         <span id='synchButtonText'></span>
       </button>
 
-      <div id='dataTable-controls' class="end">
-        <button id='backButton' class="miro-btn miro-btn--primary miro-btn--small"
-        style="background-image: url(./img/arrow-left.svg);  background-size: 100% 100%;  border: 0;  padding: 8px 15px;"></button>
-        <label id='pageLabel' style="margin-left: 20px; margin-right: 20px;"></label>
-        <button id='forwardButton' class="miro-btn miro-btn--primary miro-btn--small"
-        style="background-image: url(./img/arrow-right.svg);  background-size: 100% 100%;  border: 0;  padding: 8px 15px;"></button>
-      </div>
     </footer>
   </div>
 

--- a/src/pages/picker/picker.ts
+++ b/src/pages/picker/picker.ts
@@ -426,7 +426,6 @@ async function generateTableContent(tableBody: HTMLTableSectionElement, data: an
     }
 
     for (let key in element) {
-      console.log(key);
       let cell = row.insertCell();
       let text = document.createTextNode(element[key]);
       cell.appendChild(text);
@@ -605,7 +604,6 @@ async function loadAndAppendNextResultPage() {
   const queryString = `tracker.id IN (${selectedTracker})${subQuery}`;
   
   const items: any[] = (await CodeBeamerService.getInstance().getCodeBeamerCbqlResult(queryString, currentResultsPage++, DEFAULT_ITEMS_PER_PAGE)).items;
-  console.log("Items to add: ", items);
 
   appendResultsToDataTable(items);
   currentResultItems.push(items);


### PR DESCRIPTION
implementation of RETINA-1565419

- Removes results-table pagination controls
- Adds scrolling to the results-table
- Adds a lazy-load button to load more items at the bottom of the table
- Restyles the results-table
- Removes the obsolete "Tracker" column from the results-table

BUG: CBQL results lazy load overwritten by simple-search-criteria