### PR TITLE
Ipa/feature/differentiate associations 1565416

### DIFF
--- a/manual-tests/1565416.feature
+++ b/manual-tests/1565416.feature
@@ -1,0 +1,28 @@
+# Deckt den nicht-automatisierten Teil der Test-Suite für die beschriebene Funktionalität
+# In diesem Fall die korrekte Darstellung von verschiedenen Assoziationen auf dem Miro Board.
+
+Funktionalität: Visuelle Unterscheidung verschiedener Assoziationen zwischen Items
+
+    Die neun Assoziationstypen in codeBeamer sollen unterschiedlich visualisiert werden.
+
+    Grundlage: 
+        Angenommen ich bin Mitglied im "Toolchains@Temp" Projekt auf Retina-Test
+		Und ich habe das Plugin auf das "Toolchains@Temp" Projekt auf Retina-Test konfiguriert und mich authentifiziert
+        Und ich habe bin auf einem leeren Miro-Board
+		Und ich habe das "Import Items from codeBeamer" Modal geöffnet
+        Und ich habe "Miro Sync Tests by urecha" als Tracker ausgewählt
+
+    Szenario: Korrekte Darstellung einer "<assoziationsTyp>" Assoziation
+        Wenn ich die Items "<firstItem>" und "<secondItem>" für den Import auswähle
+        Und den "Import" Button drücke
+        Dann werden die beiden Items als Miro Cards generiert
+        Und eine gestrichelte Verbindungslinie besteht zwischen den beiden Items
+        Und die Verbindungslinie ist "<farbe>"
+        Und sie hat die Beschreibung "<assoziationsTyp>"
+        Und ihr Pfeil geht von Item "<secondItem>" zu Item "<firstItem>"
+
+        Beispiele: 
+        | assoziationsTyp | farbe | firstItem | secondItem |
+        | depends on | rot | 1599511 | 1599512 |
+        | copy of | türkis | 1599514 | 1599513 |
+        | subordinate to | hellgrün | 1599513 | 1599511 |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Max Poprawe",
   "name": "codebeamer-miro",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "license": "AGPL-3.0",
   "files": [
     "src/**/*"

--- a/src/constants/cb-associations.ts
+++ b/src/constants/cb-associations.ts
@@ -1,0 +1,51 @@
+/**
+ * Array of the standard codebeamer associations.
+ * Persisted here for increased performance.
+ */
+export const CODEBEAMER_ASSOCIATIONS = [
+    {
+        id: 1,
+        name: "depends",
+        color: "#ff1500"
+    },
+    {
+        id: 2,
+        name: "parent",
+        color: "#008c00"
+    },
+    {
+        id: 3,
+        name: "child",
+        color: "#FFA500"
+    },
+    {
+        id: 4,
+        name: "related",
+        color: "#0066CC"
+    },
+    {
+        id: 5,
+        name: "derived",
+        color: "#ADD8E8"
+    },
+    {
+        id: 6,
+        name: "violates",
+        color: "#c9b00e"
+    },
+    {
+        id: 7,
+        name: "excludes",
+        color: "#FF00FF"
+    },
+    {
+        id: 8,
+        name: "invalidates",
+        color: "#7100ff"
+    },
+    {
+        id: 9,
+        name: "copy of",
+        color: "#00008b"
+    }
+]

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -4,3 +4,4 @@ export * from './cb-relation-names';
 export * from './plugin-widget';
 export * from './svg';
 export * from './widget-initial-position-name';
+export * from './cb-associations';

--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <!--sync version number with console log in init.ts-->
-  <title>CB-Miro v0.8.1</title>
+  <title>CB-Miro v0.9.0</title>
   <link type="stylesheet" href="styles/index.css">
   <style>
     body {
@@ -43,7 +43,7 @@
     <img src="img/miro-Logo.png"/>
   </div>
   <h3>
-    codeBeamer synchronizer plugin for Miro v0.8.1
+    codeBeamer synchronizer plugin for Miro v0.9.0
     <br>
       by 
       <a href="https://github.com/max-poprawe">max-poprawe</a>, 

--- a/src/init.ts
+++ b/src/init.ts
@@ -77,7 +77,7 @@ miro.onReady(async () => {
 	});
 
 	console.info(
-		`[codeBeamer-sync] Plugin v0.8.1 initialized. Experiencing issues? Let us know at https://github.com/codeBeamer-Extensions-and-Addons/codebeamer-miro/issues`
+		`[codeBeamer-sync] Plugin v0.9.0 initialized. Experiencing issues? Let us know at https://github.com/codeBeamer-Extensions-and-Addons/codebeamer-miro/issues`
 	);
 });
 

--- a/src/services/miro.ts
+++ b/src/services/miro.ts
@@ -102,7 +102,7 @@ export default class MiroService {
 			console.error(error);
 		}
 		let itemId = widget.metadata[Store.getInstance().appId].id;
-		console.log(
+		console.info(
 			`[codeBeamer-sync] ${widget.type} widget ${
 				widget.id
 			} has been created to match item ${
@@ -147,7 +147,7 @@ export default class MiroService {
 	async updateWidget(widgetData) {
 		let widget = (await miro.board.widgets.update(widgetData))[0];
 		let itemId = widget.metadata[Store.getInstance().appId].id;
-		console.log(
+		console.info(
 			`[codeBeamer-sync] ${widget.type} widget ${
 				widget.id
 			} has been updated to match item ${
@@ -300,20 +300,16 @@ export default class MiroService {
 	async convert2Line(relation, fromCardId, toCardId) {
 		let caption = '';
 		let relationDetails: any;
-		console.log("convert2line start");		
 		
 		if (relation.type === RELATION_OUT_ASSOCIATION_TYPE) {
-			console.log("outgoing association");		
 			relationDetails =
 			await CodeBeamerService.getInstance().getCodeBeamerAssociationDetails(
 				relation.id.toString()
 				);
-			console.log("relation details: ", relationDetails);	
 			caption = CODEBEAMER_ASSOCIATIONS.find(type => type.id == relationDetails.type.id)?.name ?? '';
-			console.log("caption: ", caption);	
 		}
 
-		let line = {
+		return {
 			type: "LINE",
 			startWidgetId: fromCardId,
 			endWidgetId: toCardId,
@@ -328,8 +324,6 @@ export default class MiroService {
 				},
 			},
 		};
-		console.log("line: ", JSON.stringify(line));
-		return line;
 	}
 
 	/**


### PR DESCRIPTION
Implements RETINA-1565416

Redefines how item-associations are visualized.
No longer are there just three kinds, but all nine have their own color, while all being dashed lines of thickness 2.

Captions describing the relations have also been added, yet Miro seemingly fails to display them.
A respective BUG has been created: RETINA-1599527 and a support ticket in miro opened: https://community.miro.com/developer-platform-and-apis-57/programmatic-creation-of-linewidgets-with-captions-sdk-v1-1-7345