### PR TITLE
Ipa/refactor/import config 1565413

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Max Poprawe",
   "name": "codebeamer-miro",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "license": "AGPL-3.0",
   "files": [
     "src/**/*"

--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <!--sync version number with console log in init.ts-->
-  <title>CB-Miro v0.9.2</title>
+  <title>CB-Miro v0.9.3</title>
   <link type="stylesheet" href="styles/index.css">
   <style>
     body {
@@ -43,7 +43,7 @@
     <img src="img/miro-Logo.png"/>
   </div>
   <h3>
-    codeBeamer synchronizer plugin for Miro v0.9.2
+    codeBeamer synchronizer plugin for Miro v0.9.3
     <br>
       by 
       <a href="https://github.com/max-poprawe">max-poprawe</a>, 

--- a/src/init.ts
+++ b/src/init.ts
@@ -77,7 +77,7 @@ miro.onReady(async () => {
 	});
 
 	console.info(
-		`[codeBeamer-sync] Plugin v0.9.2 initialized. Experiencing issues? Let us know at https://github.com/codeBeamer-Extensions-and-Addons/codebeamer-miro/issues`
+		`[codeBeamer-sync] Plugin v0.9.3 initialized. Experiencing issues? Let us know at https://github.com/codeBeamer-Extensions-and-Addons/codebeamer-miro/issues`
 	);
 });
 

--- a/src/pages/picker/picker.ts
+++ b/src/pages/picker/picker.ts
@@ -737,7 +737,7 @@ function saveStandardImportConfigurationValue(event: any) {
   }
 
   importConfiguration.standard[target.value] = target.checked;
-  Store.getInstance().saveImportConfiguration(importConfiguration);
+  Store.getInstance().saveBoardSettings({ importConfiguration: importConfiguration });
 }
 
 /**

--- a/src/pages/picker/picker.ts
+++ b/src/pages/picker/picker.ts
@@ -737,7 +737,7 @@ function saveStandardImportConfigurationValue(event: any) {
   }
 
   importConfiguration.standard[target.value] = target.checked;
-  Store.getInstance().saveBoardSettings({ importConfiguration: importConfiguration });
+  Store.getInstance().saveBoardSettings({ [BoardSetting.IMPORT_CONFIGURATION]: importConfiguration });
 }
 
 /**

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -94,22 +94,6 @@ export default class Store {
 	}
 
 	/**
-	 * Saves the import configuration in the board settings.
-	 * @param configuration Updated ImportConfiguration to save
-	 */
-	public async saveImportConfiguration(configuration: ImportConfiguration) {
-		const data = localStorage.getItem(
-			this.getBoardSettingsLocalStorageKey()
-		);
-		let boardSettings = data === null ? {} : JSON.parse(data);
-
-		//key of the object assigned here must equal the BoardSetting.IMPORT_CONFIGURATION enum's value to work (be readable).
-		Object.assign(boardSettings, { importConfiguration: configuration});
-
-		this.saveBoardSettings(boardSettings);
-	}
-
-	/**
 	 * Saves given settings in the localStorage.
 	 * @param settings Settings object to save.
 	 */


### PR DESCRIPTION
Minor refactor for the import-configuration backend.

- Remove obsolete, seperate method to explicitly store importSettings.
- Use enum value for property access