### PR TITLE
Fix build configuration Release 1.0.0

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -24,6 +24,7 @@ export default defineConfig({
 			input: allHtmlEntries,
 		},
 	},
+	base: '/codebeamer-miro/',
 	plugins: [reactRefresh()],
 	server: {
 		host: '127.0.0.1',


### PR DESCRIPTION
The deployed files wouldn't properly load, since apparently one needs to specify the `base` value/path in the `vite.config.js` to make it work, as neatly described [here](https://vitejs.dev/guide/static-deploy.html#github-pages)