### PR TITLE
Refactor/item details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     Links and native codebeamer images (not user-uploaded ones) should now be displayed properly and functionally.
 -   Add codeBeamer address & Item id attempted to fetch from in the fatal error message shown on an Item's Details if unable to load  
     This should clarify the fact that the currently set address is used for querying Items.
+-   Labels of the editable attributes on the Item Details Panel now use the custom name they have in the respective Tracker
 
 #### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### [1.2.0]
+
+#### Changed
+
+-   Optimize description rendering in Item Details  
+    Links and native codebeamer images (not user-uploaded ones) should now be displayed properly and functionally.
+-   Add codeBeamer address & Item id attempted to fetch from in the fatal error message shown on an Item's Details if unable to load  
+    This should clarify the fact that the currently set address is used for querying Items.
+
+#### Fixed
+
+-   Fixed a bug where upon opening an Item's details, the description shown on the Miro Card would "revert" to wiki markup.
+
+## Released
+
 ### [1.1.0]
 
 Version 1.1.0 adds the ability to edit certain attributes of an item in Miro itself and adds various minor fixes / optimizations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Add codeBeamer address & Item id attempted to fetch from in the fatal error message shown on an Item's Details if unable to load  
     This should clarify the fact that the currently set address is used for querying Items.
 -   Labels of the editable attributes on the Item Details Panel now use the custom name they have in the respective Tracker
+-   Attributes in the "Editable attributes" that can't be edited (don't exist) for this Item are now hidden instead of just disabled.
 
 #### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
 				"@types/react-dom": "18.0.6",
 				"@types/sanitize-html": "^2.6.2",
 				"@vitejs/plugin-react-refresh": "1.3.6",
-				"cypress": "^10.7.0",
+				"cypress": "^11.2.0",
 				"typescript": "4.7.4",
 				"vite": "3.0.3"
 			}
@@ -1404,9 +1404,9 @@
 			"integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
 		},
 		"node_modules/cypress": {
-			"version": "10.7.0",
-			"resolved": "https://registry.npmjs.org/cypress/-/cypress-10.7.0.tgz",
-			"integrity": "sha512-gTFvjrUoBnqPPOu9Vl5SBHuFlzx/Wxg/ZXIz2H4lzoOLFelKeF7mbwYUOzgzgF0oieU2WhJAestQdkgwJMMTvQ==",
+			"version": "11.2.0",
+			"resolved": "https://registry.npmjs.org/cypress/-/cypress-11.2.0.tgz",
+			"integrity": "sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
@@ -1429,7 +1429,7 @@
 				"dayjs": "^1.10.4",
 				"debug": "^4.3.2",
 				"enquirer": "^2.3.6",
-				"eventemitter2": "^6.4.3",
+				"eventemitter2": "6.4.7",
 				"execa": "4.1.0",
 				"executable": "^4.1.1",
 				"extract-zip": "2.0.1",
@@ -5177,9 +5177,9 @@
 			"integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
 		},
 		"cypress": {
-			"version": "10.7.0",
-			"resolved": "https://registry.npmjs.org/cypress/-/cypress-10.7.0.tgz",
-			"integrity": "sha512-gTFvjrUoBnqPPOu9Vl5SBHuFlzx/Wxg/ZXIz2H4lzoOLFelKeF7mbwYUOzgzgF0oieU2WhJAestQdkgwJMMTvQ==",
+			"version": "11.2.0",
+			"resolved": "https://registry.npmjs.org/cypress/-/cypress-11.2.0.tgz",
+			"integrity": "sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==",
 			"dev": true,
 			"requires": {
 				"@cypress/request": "^2.88.10",
@@ -5201,7 +5201,7 @@
 				"dayjs": "^1.10.4",
 				"debug": "^4.3.2",
 				"enquirer": "^2.3.6",
-				"eventemitter2": "^6.4.3",
+				"eventemitter2": "6.4.7",
 				"execa": "4.1.0",
 				"executable": "^4.1.1",
 				"extract-zip": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"@types/react-dom": "18.0.6",
 		"@types/sanitize-html": "^2.6.2",
 		"@vitejs/plugin-react-refresh": "1.3.6",
-		"cypress": "^10.7.0",
+		"cypress": "^11.2.0",
 		"typescript": "4.7.4",
 		"vite": "3.0.3"
 	}

--- a/src/api/miro.api.ts
+++ b/src/api/miro.api.ts
@@ -92,6 +92,7 @@ export async function convertToCardData(
 	item: CodeBeamerItem,
 	appStore?: EnhancedStore<any>
 ): Promise<Partial<AppCard>> {
+	let description = item.description;
 	if (item.descriptionFormat == DescriptionFormat.WIKI) {
 		const username = store.getState().userSettings.cbUsername;
 		const password = store.getState().userSettings.cbPassword;
@@ -106,14 +107,14 @@ export async function convertToCardData(
 		};
 
 		try {
-			item.description = await (
-				await fetch(
-					`${store.getState().boardSettings.cbAddress}/rest/item/${
-						item.id
-					}/wiki2html`,
-					requestArgs
-				)
-			).text();
+			const wiki2htmlRes = await fetch(
+				`${store.getState().boardSettings.cbAddress}/rest/item/${
+					item.id
+				}/wiki2html`,
+				requestArgs
+			);
+			const html = await wiki2htmlRes.text();
+			description = html;
 		} catch (e: any) {
 			//* It can in fact take ~1 minute until the request actually fails.
 			//* Issue lies with codeBeamers inability to accept its failure in converting some wiki2html
@@ -131,7 +132,7 @@ export async function convertToCardData(
 			item.name,
 			item.tracker.keyName
 		),
-		description: item.description,
+		description: description,
 		fields: [],
 		status: 'connected',
 	};

--- a/src/api/utils/addContextToCBLinks.cy.ts
+++ b/src/api/utils/addContextToCBLinks.cy.ts
@@ -6,7 +6,7 @@ describe('addContextToCBLinks', () => {
 	it('replaces relative- with absolute path to codebeamer resources', () => {
 		const mockCbAddress = 'https://mockbeamer.com/cb';
 
-		const expectedResult = `<span class="wikIContent"><p>This is a ref to <img src="${mockCbAddress}/images/issuetypes/user.gif" data-hover-tooltip-target="" class="customizable-tracker-icon" style="background-color:#5f5f5f; margin-right:2px;"><a class="interwikilink" href="${mockCbAddress}/userdata/55" title="[USER:2222]>pjotr</a>, one of our users.</p></span>`;
+		const expectedResult = `<span class="wikIContent"><p>This is a ref to <img src="${mockCbAddress}/images/issuetypes/user.gif" data-hover-tooltip-target="" class="customizable-tracker-icon" style="background-color:#5f5f5f; margin-right:2px;"><a target="_blank" class="interwikilink" href="${mockCbAddress}/userdata/55" title="[USER:2222]>pjotr</a>, one of our users.</p></span>`;
 
 		const result = addContextToCBLinks(mockCbAddress, sampleText);
 

--- a/src/api/utils/addContextToCBLinks.cy.ts
+++ b/src/api/utils/addContextToCBLinks.cy.ts
@@ -1,0 +1,15 @@
+import addContextToCBLinks from './addContextToCBLinks';
+
+const sampleText = `<span class="wikIContent"><p>This is a ref to <img src="/cb/images/issuetypes/user.gif" data-hover-tooltip-target="" class="customizable-tracker-icon" style="background-color:#5f5f5f; margin-right:2px;"><a class="interwikilink" href="/cb/userdata/55" title="[USER:2222]>pjotr</a>, one of our users.</p></span>`;
+
+describe('addContextToCBLinks', () => {
+	it('replaces relative- with absolute path to codebeamer resources', () => {
+		const mockCbAddress = 'https://mockbeamer.com/cb';
+
+		const expectedResult = `<span class="wikIContent"><p>This is a ref to <img src="${mockCbAddress}/images/issuetypes/user.gif" data-hover-tooltip-target="" class="customizable-tracker-icon" style="background-color:#5f5f5f; margin-right:2px;"><a class="interwikilink" href="${mockCbAddress}/userdata/55" title="[USER:2222]>pjotr</a>, one of our users.</p></span>`;
+
+		const result = addContextToCBLinks(mockCbAddress, sampleText);
+
+		expect(result).to.equal(expectedResult);
+	});
+});

--- a/src/api/utils/addContextToCBLinks.ts
+++ b/src/api/utils/addContextToCBLinks.ts
@@ -1,0 +1,18 @@
+const hrefRegex = /href\=\"\/cb/g;
+const srcRegex = /src\=\"\/cb/g;
+
+/**
+ * Updates src- and href attributes in given value to absolute paths, if they start with /cb
+ * @param cbBaseUrl BaseURL of the intended cb instance ending with "/cb"
+ * @param value String to update the links in
+ * @returns String with relative cb-paths replaced by absolute ones and links having target="_blank"
+ */
+export default function addContextToCBLinks(cbBaseUrl: string, value: string) {
+	console.log(value.match(hrefRegex));
+	value = value.replaceAll(hrefRegex, `href="${cbBaseUrl}`);
+	value = value.replaceAll(srcRegex, `src="${cbBaseUrl}`);
+
+	value = value.replaceAll(/\<a /g, `<a target="_blank" `);
+
+	return value;
+}

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -362,17 +362,17 @@ body {
 /**animations*/
 
 .fade-in {
-	animation: fade-in 0.6s ease-in-out forwards;
+	animation: fade-in 0.6s ease-in-out;
 }
 .fade-in-quick {
-	animation: fade-in 0.3s ease-in-out forwards;
+	animation: fade-in 0.3s ease-in-out;
 }
 .fade-in-slow {
-	animation: fade-in 1s ease-in-out forwards;
+	animation: fade-in 1s ease-in-out;
 }
 
 .fade-out {
-	animation: fade-out 0.3s ease-in-out forwards;
+	animation: fade-out 0.3s ease-in-out;
 }
 
 /**keyframes*/

--- a/src/pages/item/itemDetails.cy.tsx
+++ b/src/pages/item/itemDetails.cy.tsx
@@ -299,39 +299,6 @@ describe('<ItemDetails>', () => {
 				}
 			);
 		});
-
-		it('has a button to zoom to the item with', () => {
-			cy.getBySel('zoom-to-item').should('exist');
-		});
-
-		it('zooms to the item on the board when the button is clicked', () => {
-			cy.on('uncaught:exception', (err) => {
-				//* not providing a new fixture for each page, so we'll get duplicates.
-				if (err.message.includes('existingAppCard.sync')) {
-					return false;
-				}
-				return true;
-			});
-
-			cy.spy(miro.board.viewport, 'zoomTo').as('zoomToSpy');
-
-			const itemOne: Partial<AppCard> = {
-				id: '1',
-				title: '[RETUS-1]',
-			};
-
-			const stubBoardGet = cy.stub(miro.board, 'get').callsFake(() => {
-				return Promise.resolve([itemOne]);
-			});
-
-			cy.getBySel('zoom-to-item')
-				.click()
-				.then(() => {
-					cy.get('@zoomToSpy').then((spy) => {
-						expect(spy).to.be.called;
-					});
-				});
-		});
 	});
 
 	afterEach(() => {

--- a/src/pages/item/itemDetails.cy.tsx
+++ b/src/pages/item/itemDetails.cy.tsx
@@ -306,28 +306,6 @@ describe('<ItemDetails>', () => {
 		});
 	});
 
-	describe('zoomTo button', () => {
-		beforeEach(() => {
-			const store = getStore();
-			const mockCbAddress = 'https://test.me/cb';
-			store.dispatch(setCbAddress(mockCbAddress));
-
-			cy.intercept(`**/api/v3/items/${mockItemId}`, {
-				fixture: 'item.json',
-			});
-			cy.intercept(`**/api/v3/trackers/*/schema`, {
-				fixture: 'tracker_schema.json',
-			});
-
-			cy.mountWithStore(
-				<ItemDetails itemId={mockItemId} cardId={mockCardId} />,
-				{
-					reduxStore: store,
-				}
-			);
-		});
-	});
-
 	afterEach(() => {
 		localStorage.clear();
 		sessionStorage.clear();

--- a/src/pages/item/itemDetails.cy.tsx
+++ b/src/pages/item/itemDetails.cy.tsx
@@ -3,6 +3,7 @@ import ItemDetails from './itemDetails';
 import {
 	ASSIGNEE_FIELD_NAME,
 	EDITABLE_ATTRIBUTES,
+	STORY_POINTS_FIELD_NAME,
 	SUBJECT_FIELD_NAME,
 	TEAM_FIELD_NAME,
 } from '../../constants/editable-attributes';
@@ -49,6 +50,28 @@ describe('<ItemDetails>', () => {
 				cy.getBySel(attr.name).should('exist');
 			}
 		});
+		it('labels the inputs according to their name in the item its tracker', () => {
+			cy.intercept(`**/api/v3/trackers/*/schema`, {
+				fixture: 'tracker_schema.json',
+			}).as('schema');
+
+			cy.wait('@schema');
+
+			cy.fixture('tracker_schema.json').then((fixture) => {
+				for (let attr of EDITABLE_ATTRIBUTES) {
+					console.log(fixture);
+					let name =
+						fixture.find(
+							(i) =>
+								i.legacyRestName == attr.legacyName ||
+								i.trackerItemField == attr.name
+						)?.name ?? '';
+
+					if (attr.name == STORY_POINTS_FIELD_NAME) continue;
+					cy.getBySel(attr.name).should('contain.text', name);
+				}
+			});
+		});
 
 		it('disables the input if the current tracker has no such field', () => {
 			cy.intercept('**/api/v3/trackers/*/schema', {
@@ -77,6 +100,10 @@ describe('<ItemDetails>', () => {
 			});
 			cy.intercept(`**/api/v3/trackers/*/schema`, {
 				fixture: 'tracker_schema.json',
+			});
+			cy.intercept('**/wiki2html', {
+				statusCode: 200,
+				body: 'Just some testing text',
 			});
 
 			cy.mountWithStore(

--- a/src/pages/item/itemDetails.tsx
+++ b/src/pages/item/itemDetails.tsx
@@ -172,9 +172,9 @@ export default function ItemDetails(props: {
 				"Fatal error - couldn't load item schema: ",
 				itemQueryResult.error
 			);
-			//TODO improve
-			setFatalError('Failed loading item schema');
-			return;
+			setFatalError(
+				`Failed loading item schema from ${cbAddress} for Item with Id ${itemId}`
+			);
 		} else if (itemQueryResult.data) {
 			setTrackerId(itemQueryResult.data.tracker.id.toString());
 			setItem(itemQueryResult.data);

--- a/src/pages/item/itemDetails.tsx
+++ b/src/pages/item/itemDetails.tsx
@@ -300,6 +300,15 @@ export default function ItemDetails(props: {
 		}
 	}, [fieldOptionsQueryResult.data]);
 
+	const getFieldLabel = (fieldName: string): string => {
+		if (!trackerSchemaQueryResult.data) return fieldName;
+		let label = trackerSchemaQueryResult.data.find(
+			(r) =>
+				r.legacyRestName == fieldName || r.trackerItemField == fieldName
+		)?.name;
+		return label ?? fieldName;
+	};
+
 	/**
 	 * @returns Whether the field for {@link fieldName} should be disabled (true) or not (false)
 	 */
@@ -412,7 +421,7 @@ export default function ItemDetails(props: {
 								}
 							>
 								<label data-test={ASSIGNEE_FIELD_NAME}>
-									Assignee
+									{getFieldLabel(ASSIGNEE_FIELD_NAME)}
 								</label>
 								<Select
 									className="basic-single"
@@ -468,7 +477,9 @@ export default function ItemDetails(props: {
 								}`}
 								onClick={() => fetchOptions(TEAM_FIELD_NAME)}
 							>
-								<label data-test={TEAM_FIELD_NAME}>Team</label>
+								<label data-test={TEAM_FIELD_NAME}>
+									{getFieldLabel(TEAM_FIELD_NAME)}
+								</label>
 								<Select
 									className="basic-single"
 									classNamePrefix="select"
@@ -525,7 +536,7 @@ export default function ItemDetails(props: {
 								onClick={() => fetchOptions(VERSION_FIELD_NAME)}
 							>
 								<label data-test={VERSION_FIELD_NAME}>
-									Version
+									{getFieldLabel(VERSION_FIELD_NAME)}
 								</label>
 								<Select
 									className="basic-single"
@@ -583,7 +594,7 @@ export default function ItemDetails(props: {
 								onClick={() => fetchOptions(SUBJECT_FIELD_NAME)}
 							>
 								<label data-test={SUBJECT_FIELD_NAME}>
-									Subject
+									{getFieldLabel(SUBJECT_FIELD_NAME)}
 								</label>
 								<Select
 									className="basic-single"
@@ -638,7 +649,9 @@ export default function ItemDetails(props: {
 										: ''
 								}`}
 							>
-								<label>Story Points</label>
+								<label>
+									{getFieldLabel(STORY_POINTS_FIELD_NAME)}
+								</label>
 								<input
 									type="number"
 									className="input"

--- a/src/pages/item/itemDetails.tsx
+++ b/src/pages/item/itemDetails.tsx
@@ -409,7 +409,11 @@ export default function ItemDetails(props: {
 								//*********************************************************************** */
 							}
 							<div
-								className={`form-group ${
+								hidden={
+									!trackerSchemaQueryResult.data ||
+									fieldIsDisabled(ASSIGNEE_FIELD_NAME)
+								}
+								className={`form-group fade-in-quick${
 									formik.touched.assignedTo
 										? formik.errors.assignedTo
 											? 'error'
@@ -468,7 +472,11 @@ export default function ItemDetails(props: {
 								//*********************************************************************** */
 							}
 							<div
-								className={`form-group ${
+								hidden={
+									!trackerSchemaQueryResult.data ||
+									fieldIsDisabled(TEAM_FIELD_NAME)
+								}
+								className={`form-group fade-in-quick${
 									formik.touched.teams
 										? formik.errors.teams
 											? 'error'
@@ -526,7 +534,11 @@ export default function ItemDetails(props: {
 							}
 
 							<div
-								className={`form-group ${
+								hidden={
+									!trackerSchemaQueryResult.data ||
+									fieldIsDisabled(VERSION_FIELD_NAME)
+								}
+								className={`form-group fade-in-quick${
 									formik.touched.versions
 										? formik.errors.versions
 											? 'error'
@@ -584,7 +596,11 @@ export default function ItemDetails(props: {
 							}
 
 							<div
-								className={`form-group ${
+								hidden={
+									!trackerSchemaQueryResult.data ||
+									fieldIsDisabled(SUBJECT_FIELD_NAME)
+								}
+								className={`form-group fade-in-quick${
 									formik.touched.subjects
 										? formik.errors.subjects
 											? 'error'
@@ -641,7 +657,11 @@ export default function ItemDetails(props: {
 								//*********************************************************************** */
 							}
 							<div
-								className={`form-group ${
+								hidden={
+									!trackerSchemaQueryResult.data ||
+									fieldIsDisabled(STORY_POINTS_FIELD_NAME)
+								}
+								className={`form-group fade-in-quick${
 									formik.touched.storyPoints
 										? formik.errors.storyPoints
 											? 'error'

--- a/src/pages/item/itemSummary/ItemSummary.tsx
+++ b/src/pages/item/itemSummary/ItemSummary.tsx
@@ -1,0 +1,93 @@
+import React, { useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useLazyGetWiki2HtmlLegacyQuery } from '../../../api/codeBeamerApi';
+import addContextToCBLinks from '../../../api/utils/addContextToCBLinks';
+import { CodeBeamerItem } from '../../../models/codebeamer-item.if';
+import { displayAppMessage } from '../../../store/slices/appMessagesSlice';
+import { RootState } from '../../../store/store';
+
+export default function ItemSummary(props: {
+	item: Partial<CodeBeamerItem>;
+	cardId?: string;
+	canZoomToItem?: boolean;
+}) {
+	const dispatch = useDispatch();
+
+	const { cbAddress } = useSelector(
+		(state: RootState) => state.boardSettings
+	);
+
+	const [displayedItemDescription, setDisplayedItemDescription] =
+		useState<string>(props.item.description ?? '');
+
+	const [triggerWiki2HtmlQuery, wiki2HtmlQueryResult] =
+		useLazyGetWiki2HtmlLegacyQuery();
+
+	React.useEffect(() => {
+		if (!props.item.id || !props.item.description) {
+			return;
+		}
+		triggerWiki2HtmlQuery({
+			itemId: props.item.id!,
+			markup: props.item.description!,
+		});
+	}, [props.item.description]);
+
+	React.useEffect(() => {
+		if (wiki2HtmlQueryResult.error) {
+			console.warn('Failed to convert wiki description to html');
+		}
+		if (wiki2HtmlQueryResult.data) {
+			setDisplayedItemDescription(
+				cbAddress
+					? addContextToCBLinks(cbAddress, wiki2HtmlQueryResult.data)
+					: wiki2HtmlQueryResult.data
+			);
+		}
+	}, [wiki2HtmlQueryResult]);
+
+	const zoomToWidget = async () => {
+		const errorMessage = {
+			header: 'Error',
+			content: "Can't find the item on the board!",
+			bg: 'warning',
+		};
+		if (!props.cardId) {
+			dispatch(displayAppMessage(errorMessage));
+			return;
+		}
+		let widget = await miro.board.getById(props.cardId);
+		if (!widget) {
+			dispatch(displayAppMessage(errorMessage));
+		}
+		miro.board.viewport.zoomTo(widget);
+	};
+
+	return (
+		<>
+			<div className="title sticky">
+				<h3 className="h3" data-test="summary-summary">
+					{props.item.name}
+					{props.item.id && <small> #{props.item.id} </small>}
+					{props.canZoomToItem && props.cardId && (
+						<span
+							className="icon icon-eye clickable pos-adjusted-down"
+							title="Click to zoom to the item"
+							onClick={() => zoomToWidget()}
+							data-test="summary-zoom-to-item"
+						></span>
+					)}
+				</h3>
+			</div>
+			{displayedItemDescription && (
+				<p
+					data-test="summary-description"
+					className="overflow-ellipsis"
+					dangerouslySetInnerHTML={{
+						__html: displayedItemDescription,
+					}}
+				></p>
+			)}
+		</>
+	);
+}

--- a/src/pages/item/itemSummary/ItemSummary.tsx
+++ b/src/pages/item/itemSummary/ItemSummary.tsx
@@ -9,7 +9,6 @@ import { RootState } from '../../../store/store';
 export default function ItemSummary(props: {
 	item: Partial<CodeBeamerItem>;
 	cardId?: string;
-	canZoomToItem?: boolean;
 }) {
 	const dispatch = useDispatch();
 
@@ -69,7 +68,7 @@ export default function ItemSummary(props: {
 				<h3 className="h3" data-test="summary-summary">
 					{props.item.name}
 					{props.item.id && <small> #{props.item.id} </small>}
-					{props.canZoomToItem && props.cardId && (
+					{props.cardId && (
 						<span
 							className="icon icon-eye clickable pos-adjusted-down"
 							title="Click to zoom to the item"

--- a/src/pages/item/itemSummary/itemSummary.cy.tsx
+++ b/src/pages/item/itemSummary/itemSummary.cy.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import { CodeBeamerItem } from '../../../models/codebeamer-item.if';
+import { setCbAddress } from '../../../store/slices/boardSettingsSlice';
+import { getStore } from '../../../store/store';
+import ItemSummary from './ItemSummary';
+
+const mockItem: Partial<CodeBeamerItem> = {
+	name: 'Mock the ITem',
+	id: 52342,
+	description: 'Lorem ipsum doler set amur and so on',
+};
+
+const mockCardId = 329329;
+
+const summarySelector = 'summary-summary';
+const zoomSelector = 'summary-zoom-to-item';
+const descriptionSelector = 'summary-description';
+
+describe('<ItemSummary>', () => {
+	it('mounts', () => {
+		cy.mountWithStore(<ItemSummary item={mockItem} />);
+	});
+
+	describe('item values', () => {
+		beforeEach(() => {
+			cy.mountWithStore(<ItemSummary item={mockItem} />);
+		});
+
+		it('displays the item its name', () => {
+			cy.getBySel(summarySelector)
+				.should('exist')
+				.and('contain.text', mockItem.name);
+		});
+
+		it('displays the item its description', () => {
+			cy.getBySel(descriptionSelector)
+				.should('exist')
+				.and('contain.text', mockItem.description);
+		});
+	});
+	it('converts the item its description from wiki to html', () => {
+		const store = getStore();
+		const mockAddress = 'https://mock.cb.com/cb';
+		store.dispatch(setCbAddress(mockAddress));
+		cy.intercept('POST', `**/wiki2html`, { statusCode: 200 }).as(
+			'wiki2html'
+		);
+
+		cy.mountWithStore(<ItemSummary item={mockItem} />, {
+			reduxStore: store,
+		});
+
+		cy.wait('@wiki2html')
+			.its('request.body')
+			.should('equal', mockItem.description);
+	});
+});

--- a/src/pages/item/itemSummary/itemSummary.cy.tsx
+++ b/src/pages/item/itemSummary/itemSummary.cy.tsx
@@ -10,7 +10,7 @@ const mockItem: Partial<CodeBeamerItem> = {
 	description: 'Lorem ipsum doler set amur and so on',
 };
 
-const mockCardId = 329329;
+const mockCardId = '329329';
 
 const summarySelector = 'summary-summary';
 const zoomSelector = 'summary-zoom-to-item';
@@ -53,5 +53,34 @@ describe('<ItemSummary>', () => {
 		cy.wait('@wiki2html')
 			.its('request.body')
 			.should('equal', mockItem.description);
+	});
+	describe('zoom to item button', () => {
+		it('displays the zoom-to-item button if a card id is provided', () => {
+			cy.mountWithStore(
+				<ItemSummary item={mockItem} cardId={mockCardId} />
+			);
+
+			cy.getBySel(zoomSelector).should('exist');
+		});
+		it('zooms to the item on the board when clicked', () => {
+			const mockWidget = { name: 'mockeridoo', id: mockCardId };
+
+			cy.stub(miro.board, 'getById').returns(mockWidget);
+			cy.spy(miro.board.viewport, 'zoomTo').as('zoomToItem');
+
+			cy.mountWithStore(
+				<ItemSummary item={mockItem} cardId={mockCardId} />
+			);
+
+			cy.getBySel(zoomSelector).should('exist');
+
+			cy.getBySel(zoomSelector)
+				.click()
+				.then(() => {
+					cy.get('@zoomToItem').then((spy) => {
+						expect(spy).to.be.calledWith(mockWidget);
+					});
+				});
+		});
 	});
 });


### PR DESCRIPTION
# Refactor Item Details

...along with other minor fixes / updates.

#### Changed

#### Changed

-   Optimize description rendering in Item Details  
    Links and native codebeamer images (not user-uploaded ones*) should now be displayed properly and functionally.
-   Add codeBeamer address & Item id attempted to fetch from in the fatal error message shown on an Item's Details if unable to load  
    This should clarify the fact that the currently set address is used for querying Items.
-   Labels of the editable attributes on the Item Details Panel now use the custom name they have in the respective Tracker  
cALM US for example label their subjects as "Realized Feature" now
-   Attributes in the "Editable attributes" that can't be edited (don't exist) for this Item are now hidden instead of just disabled.

*Changes Behind the scenes*
- Refactored ItemDetails Component, outsourced "ItemSummary" into its own component.

#### Fixed

-   Fixed a bug where upon opening an Item's details, the description shown on the Miro Card would "revert" to wiki markup.

---

Item Details can now look like this for example

![image](https://user-images.githubusercontent.com/70019423/205043258-5a0d89c5-86fe-4af9-973b-dcda1966ebb8.png)

_*Non-native (uploaded) Images seem not to work. The link matches what is on codebeamer, but it doesn't display anything, and the link seems to only serve to download the image to one's device (but not display it in the browser).._
