### PR TITLE
Refine Feature/load downstream refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### [1.4.0]
+
+-   Refine "Load Downstream References" button in Item Details
+    -   Button now shows the number of Downstream References the Item has
+    -   Button is now disabled when the Item has no Downstream References
+    -   No longer loads Items, if they're already on the board (doesn't create duplicates)
+
 ## Released
+
+### [1.3.2]
+
+-   Add preliminary "Load Downstream References" button to Item Details
 
 ### [1.3.1]
 

--- a/cypress/fixtures/itemRelations.json
+++ b/cypress/fixtures/itemRelations.json
@@ -1,0 +1,149 @@
+{
+	"itemId": {
+		"id": 708109,
+		"version": 28
+	},
+	"downstreamReferences": [
+		{
+			"id": 6393192,
+			"itemRevision": {
+				"id": 695388,
+				"version": 14
+			},
+			"type": "DownstreamTrackerItemReference"
+		},
+		{
+			"id": 6309964,
+			"itemRevision": {
+				"id": 783345,
+				"version": 7
+			},
+			"type": "DownstreamTrackerItemReference"
+		},
+		{
+			"id": 6309630,
+			"itemRevision": {
+				"id": 783344,
+				"version": 8
+			},
+			"type": "DownstreamTrackerItemReference"
+		},
+		{
+			"id": 6309619,
+			"itemRevision": {
+				"id": 783343,
+				"version": 10
+			},
+			"type": "DownstreamTrackerItemReference"
+		},
+		{
+			"id": 6309607,
+			"itemRevision": {
+				"id": 783342,
+				"version": 8
+			},
+			"type": "DownstreamTrackerItemReference"
+		},
+		{
+			"id": 6309558,
+			"itemRevision": {
+				"id": 555460,
+				"version": 27
+			},
+			"type": "DownstreamTrackerItemReference"
+		},
+		{
+			"id": 6302305,
+			"itemRevision": {
+				"id": 782537,
+				"version": 8
+			},
+			"type": "DownstreamTrackerItemReference"
+		},
+		{
+			"id": 6302246,
+			"itemRevision": {
+				"id": 782536,
+				"version": 9
+			},
+			"type": "DownstreamTrackerItemReference"
+		},
+		{
+			"id": 6302087,
+			"itemRevision": {
+				"id": 782533,
+				"version": 9
+			},
+			"type": "DownstreamTrackerItemReference"
+		},
+		{
+			"id": 6302007,
+			"itemRevision": {
+				"id": 782532,
+				"version": 11
+			},
+			"type": "DownstreamTrackerItemReference"
+		},
+		{
+			"id": 6301977,
+			"itemRevision": {
+				"id": 782531,
+				"version": 10
+			},
+			"type": "DownstreamTrackerItemReference"
+		}
+	],
+	"upstreamReferences": [
+		{
+			"id": 5681748,
+			"itemRevision": {
+				"id": 708440,
+				"version": 7
+			},
+			"type": "UpstreamTrackerItemReference"
+		},
+		{
+			"id": 5664113,
+			"itemRevision": {
+				"id": 542029,
+				"version": 4
+			},
+			"type": "UpstreamTrackerItemReference"
+		},
+		{
+			"id": 5663897,
+			"itemRevision": {
+				"id": 579888,
+				"version": 94
+			},
+			"type": "UpstreamTrackerItemReference"
+		},
+		{
+			"id": 5663884,
+			"itemRevision": {
+				"id": 699766,
+				"version": 2
+			},
+			"type": "UpstreamTrackerItemReference"
+		},
+		{
+			"id": 5663880,
+			"itemRevision": {
+				"id": 542154,
+				"version": 1
+			},
+			"type": "UpstreamTrackerItemReference"
+		}
+	],
+	"incomingAssociations": [],
+	"outgoingAssociations": [
+		{
+			"id": 5663886,
+			"itemRevision": {
+				"id": 548434,
+				"version": 33
+			},
+			"type": "OutgoingTrackerItemAssociation"
+		}
+	]
+}

--- a/src/api/codeBeamerApi.ts
+++ b/src/api/codeBeamerApi.ts
@@ -214,5 +214,5 @@ export const {
 	useLazyGetFilteredUsersQuery,
 	useGetItemFieldsQuery,
 	useLazyGetFieldOptionsQuery,
-	useLazyGetItemRelationsQuery,
+	useGetItemRelationsQuery,
 } = codeBeamerApi;

--- a/src/api/utils/addContextToCBLinks.ts
+++ b/src/api/utils/addContextToCBLinks.ts
@@ -8,7 +8,6 @@ const srcRegex = /src\=\"\/cb/g;
  * @returns String with relative cb-paths replaced by absolute ones and links having target="_blank"
  */
 export default function addContextToCBLinks(cbBaseUrl: string, value: string) {
-	console.log(value.match(hrefRegex));
 	value = value.replaceAll(hrefRegex, `href="${cbBaseUrl}`);
 	value = value.replaceAll(srcRegex, `src="${cbBaseUrl}`);
 

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -298,6 +298,10 @@ img {
 	background-color: var(--indigo200) !important;
 }
 
+.button-loading-primary.button-loading:after {
+	border-color: transparent var(--blue700) var(--blue700) transparent !important;
+}
+
 /** text / overflow */
 .overflow-ellipsis {
 	text-overflow: ellipsis;

--- a/src/pages/import/components/importer/Importer.tsx
+++ b/src/pages/import/components/importer/Importer.tsx
@@ -32,24 +32,32 @@ export default function Importer(props: {
 
 	const importedItems = useImportedItems();
 
+	/**
+	 * Produces the "main query string", which defines what should be imported.
+	 * Can and should be extended by what should NOT be imported
+	 */
+	const getMainQueryString = () => {
+		if (props.queryString) return props.queryString;
+		else
+			return `${cbqlString}${
+				props.items.length
+					? ' AND item.id IN (' + props.items.join(',') + ')'
+					: ''
+			}`;
+	};
+
 	//* applies all currently active filters by using the stored cbqlString,
 	//* then further filters out only the selected items (or takes all of 'em)
 	const { data, error, isLoading } = useGetItemsQuery({
 		page: DEFAULT_RESULT_PAGE,
 		pageSize: MAX_ITEMS_PER_IMPORT,
-		queryString:
-			props.queryString ||
-			`${cbqlString}${
-				props.items.length
-					? ' AND item.id IN (' + props.items.join(',') + ')'
-					: ''
-			}${
-				importedItems.length
-					? ' AND item.id NOT IN (' +
-					  importedItems.map((i) => i.itemId) +
-					  ')'
-					: ''
-			}`,
+		queryString: `${getMainQueryString()}${
+			importedItems.length
+				? ' AND item.id NOT IN (' +
+				  importedItems.map((i) => i.itemId) +
+				  ')'
+				: ''
+		}`,
 	});
 
 	const {

--- a/src/pages/import/components/importer/Importer.tsx
+++ b/src/pages/import/components/importer/Importer.tsx
@@ -87,8 +87,9 @@ export default function Importer(props: {
 				await createAppCard(_items[i]);
 				setLoaded(i + 1);
 			}
-			await miro.board.ui.closeModal();
-			await miro.board.ui.closePanel();
+			miro.board.ui.closeModal();
+			miro.board.ui.closePanel();
+			return;
 		};
 
 		if (error || trackerDetailsQueryError) {

--- a/src/pages/item/item-actions/ItemActions.tsx
+++ b/src/pages/item/item-actions/ItemActions.tsx
@@ -45,6 +45,7 @@ export default function ItemActions(props: { itemId: string | number }) {
 				onClick={clickHandler}
 				disabled={disabled}
 				data-test="load-downstream-references"
+				title="Load the Item's Downstream References onto the board, if they're not yet there"
 			>
 				{!isLoading && (
 					<>

--- a/src/pages/item/item-actions/ItemActions.tsx
+++ b/src/pages/item/item-actions/ItemActions.tsx
@@ -44,6 +44,7 @@ export default function ItemActions(props: { itemId: string | number }) {
 				}`}
 				onClick={clickHandler}
 				disabled={disabled}
+				data-test="load-downstream-references"
 			>
 				{!isLoading && (
 					<>

--- a/src/pages/item/item-actions/itemActions.cy.tsx
+++ b/src/pages/item/item-actions/itemActions.cy.tsx
@@ -1,0 +1,102 @@
+import * as React from 'react';
+import ItemActions from './ItemActions';
+
+const mockItemId = 201284;
+
+describe('<ItemActions>', () => {
+	it('mounts', () => {
+		cy.mountWithStore(<ItemActions itemId={mockItemId} />);
+	});
+
+	describe('load-downstream-refs', () => {
+		beforeEach(() => {});
+
+		it('eagerly loads the item its relations', () => {
+			cy.intercept(`**/items/${mockItemId}/relations`, {
+				fixture: 'itemRelations.json',
+			}).as('relations');
+
+			cy.mountWithStore(<ItemActions itemId={mockItemId} />);
+
+			cy.wait('@relations');
+		});
+
+		describe('button', () => {
+			it('displays a button to load downstream references with', () => {
+				cy.intercept(`**/items/${mockItemId}/relations`, {
+					fixture: 'itemRelations.json',
+				}).as('relations');
+
+				cy.mountWithStore(<ItemActions itemId={mockItemId} />);
+				cy.wait('@relations');
+
+				cy.getBySel('load-downstream-references').should('exist');
+			});
+
+			it('displays the number of downstream references the item has in the button', () => {
+				cy.intercept(`**/items/${mockItemId}/relations`, {
+					fixture: 'itemRelations.json',
+				}).as('relations');
+
+				cy.mountWithStore(<ItemActions itemId={mockItemId} />);
+				cy.wait('@relations');
+
+				cy.fixture('itemRelations.json').then((relations) => {
+					cy.getBySel('load-downstream-references').should(
+						'contain.text',
+						`(${relations.downstreamReferences.length})`
+					);
+				});
+			});
+
+			it('disables the button while fetching the relations data', () => {
+				cy.intercept(`**/items/${mockItemId}/relations`, {
+					fixture: 'itemRelations.json',
+					delay: 500,
+				}).as('relations');
+
+				cy.mountWithStore(<ItemActions itemId={mockItemId} />);
+
+				cy.getBySel('load-downstream-references').should(
+					'have.attr',
+					'disabled'
+				);
+				cy.wait('@relations');
+				cy.getBySel('load-downstream-references').should(
+					'not.have.attr',
+					'disabled'
+				);
+			});
+
+			it('prompts the Import of all the Item its downstream references when clicked', () => {
+				cy.intercept(`**/items/${mockItemId}/relations`, {
+					fixture: 'itemRelations.json',
+					delay: 500,
+				}).as('relations');
+				cy.intercept(`**/items/query`, {
+					fixture: 'query_multi-page.json',
+				}).as('query');
+
+				cy.mountWithStore(<ItemActions itemId={mockItemId} />);
+
+				cy.wait('@relations');
+
+				cy.getBySel('load-downstream-references').click();
+				cy.getBySel('importProgress').should('exist');
+
+				cy.fixture('itemRelations.json').then((relations) => {
+					const queryString = `item.id IN (${relations.downstreamReferences.map(
+						(d: {
+							id: number;
+							itemRevision: { id: number; version: number };
+							type: string;
+						}) => d.itemRevision.id.toString()
+					)})`;
+					cy.wait('@query')
+						.its('request.body.queryString')
+						.should('equal', queryString);
+				});
+			});
+		});
+	});
+});


### PR DESCRIPTION
# Load Downstream refs refinement

## Summary

Refines the functionality to load an Item's downstream references, which was first added in #88 as a hotfix.  

## Changes

- Button is now disabled if the Item has no downstream refs
- Button shows amount of downstream refs the Item has
- Button shows a loading animation while it's loading the downstream ref data
- Added tests to `ItemActions` component (which contains said button)
- Refactored `Importer`
- Updated tests for `Importer`
- SidePanel should now close when downstream refs have been loaded

Button with No. of downstream refs

![image](https://user-images.githubusercontent.com/70019423/208843700-ec29798e-61cb-4dab-8e58-171b65a65f2f.png)

-> Disabled when 0

![image](https://user-images.githubusercontent.com/70019423/208843819-c262e71c-d153-4833-b1dc-a34785f33c86.png)

While loading

![cb-c_load_dstrrefs_loading](https://user-images.githubusercontent.com/70019423/208844078-6370b578-dfb2-4e65-b47f-62e1506c69f4.gif)
