### PR TITLE
Feature/widget metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "codebeamer-cards",
-	"version": "1.3.1",
+	"version": "1.4.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "codebeamer-cards",
-			"version": "1.3.1",
+			"version": "1.4.0",
 			"dependencies": {
 				"@reduxjs/toolkit": "^1.8.3",
 				"formik": "^2.2.9",
@@ -19,7 +19,7 @@
 				"react-select": "^5.4.0"
 			},
 			"devDependencies": {
-				"@mirohq/websdk-types": "latest",
+				"@mirohq/websdk-types": "^2.5.0",
 				"@types/cypress": "^1.1.3",
 				"@types/react": "18.0.15",
 				"@types/react-dom": "18.0.6",
@@ -652,9 +652,9 @@
 			}
 		},
 		"node_modules/@mirohq/websdk-types": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/@mirohq/websdk-types/-/websdk-types-2.4.0.tgz",
-			"integrity": "sha512-X/s5DHXlRuqLCj7f1C7h7h9Pz7eeNyDhY+FuGy+/AhT4g+X1vXrt6wp0LGecW22djezuejhZbJDWh3FcGhZH0w==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@mirohq/websdk-types/-/websdk-types-2.5.0.tgz",
+			"integrity": "sha512-ejCKqBfIRDeQ98u9ISdMbo6c8Gk0+rVS0CkcsCOhy8xIQqmBezmHPAMa7DH5o++YdgeH4ZVpIuv8+FZBU/QMdw==",
 			"dev": true,
 			"dependencies": {
 				"typescript": "4.6.3"
@@ -4595,9 +4595,9 @@
 			}
 		},
 		"@mirohq/websdk-types": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/@mirohq/websdk-types/-/websdk-types-2.4.0.tgz",
-			"integrity": "sha512-X/s5DHXlRuqLCj7f1C7h7h9Pz7eeNyDhY+FuGy+/AhT4g+X1vXrt6wp0LGecW22djezuejhZbJDWh3FcGhZH0w==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@mirohq/websdk-types/-/websdk-types-2.5.0.tgz",
+			"integrity": "sha512-ejCKqBfIRDeQ98u9ISdMbo6c8Gk0+rVS0CkcsCOhy8xIQqmBezmHPAMa7DH5o++YdgeH4ZVpIuv8+FZBU/QMdw==",
 			"dev": true,
 			"requires": {
 				"typescript": "4.6.3"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 		"react-select": "^5.4.0"
 	},
 	"devDependencies": {
-		"@mirohq/websdk-types": "latest",
+		"@mirohq/websdk-types": "^2.5.0",
 		"@types/cypress": "^1.1.3",
 		"@types/react": "18.0.15",
 		"@types/react-dom": "18.0.6",

--- a/src/api/miro.api.ts
+++ b/src/api/miro.api.ts
@@ -47,6 +47,12 @@ export async function createAppCard(
 		const widget = await miro.board.createAppCard({
 			...card,
 		});
+		await widget.setMetadata('item', {
+			id: item.id,
+			tracker: {
+				id: item.tracker.id,
+			},
+		});
 	} catch (error) {
 		console.error(error);
 	}

--- a/src/hooks/useImportedItems.ts
+++ b/src/hooks/useImportedItems.ts
@@ -2,6 +2,7 @@ import { AppCard } from '@mirohq/websdk-types';
 import React, { useState } from 'react';
 import { CARD_TITLE_ID_FILTER_REGEX } from '../constants/regular-expressions';
 import { AppCardToItemMapping } from '../models/appCardToItemMapping.if';
+import { CodeBeamerItem } from '../models/codebeamer-item.if';
 
 /**
  * Queries the AppCards present on the Miro board
@@ -15,30 +16,41 @@ export const useImportedItems = () => {
 	/**
 	 * Queries miro for the currently existing app_cards on the board.
 	 * This does mean that this plugin is currently not 100% compatible with others that would create App Cards.
-	 * TODO add an additional filter that filters for metadata, once available, to only get "our" cards
 	 */
 	React.useEffect(() => {
-		miro.board.get({ type: 'app_card' }).then((existingCards) => {
-			setImportedItems(
-				existingCards.map((e) => {
+		miro.board.get({ type: 'app_card' }).then(async (existingCards) => {
+			const importedItems = await Promise.all(
+				existingCards.map(async (e) => {
 					let card = e as AppCard;
+					let itemId;
 
-					const itemKey = card.title.match(
-						CARD_TITLE_ID_FILTER_REGEX
-					);
+					try {
+						itemId = (
+							(await card.getMetadata('item')) as Pick<
+								CodeBeamerItem,
+								'id'
+							>
+						).id.toString();
+					} catch (err: any) {
+						//fallback for backwards-compatibility
+						const itemKey = card.title.match(
+							CARD_TITLE_ID_FILTER_REGEX
+						);
 
-					if (!itemKey?.length) {
-						const message =
-							"Couldn't extract ID from Card title. Can't sync!";
-						console.error(message);
-						miro.board.notifications.showError(message);
-						return { appCardId: card.id, itemId: '' };
+						if (!itemKey?.length) {
+							const message =
+								"Couldn't extract ID from Card title. Can't sync!";
+							console.error(message);
+							miro.board.notifications.showError(message);
+							return { appCardId: card.id, itemId: '' };
+						}
+						itemId = itemKey[1];
 					}
-					const itemId = itemKey[1];
 
 					return { appCardId: card.id, itemId: itemId };
 				})
 			);
+			setImportedItems(importedItems);
 		});
 	}, []);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import getItemIdFromCardTitle from './api/utils/getItemIdFromCardTitle';
+import { CodeBeamerItem } from './models/codebeamer-item.if';
 
 async function init() {
 	miro.board.ui.on('icon:click', async () => {
@@ -11,7 +12,18 @@ async function init() {
 
 	miro.board.ui.on('app_card:open', async (_event) => {
 		const cardId = _event.appCard.id;
-		const itemId = getItemIdFromCardTitle(_event.appCard.title);
+		let itemId;
+		try {
+			itemId = (
+				(await _event.appCard.getMetadata('item')) as Pick<
+					CodeBeamerItem,
+					'id'
+				>
+			).id;
+		} catch (err: any) {
+			//fallback for backwards-compatibility
+			itemId = getItemIdFromCardTitle(_event.appCard.title);
+		}
 
 		miro.board.ui.openPanel({
 			url: `item.html?cardId=${cardId}&itemId=${itemId}`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ async function init() {
 	});
 
 	console.info(
-		`[codeBeamer-cards] Plugin v1.4.0 initialized. Experiencing issues? Let us know at https://github.com/codeBeamer-Extensions-and-Addons/codebeamer-miro/issues`
+		`[codeBeamer-cards] Plugin v1.5.0-alpha-1 initialized. Experiencing issues? Let us know at https://github.com/codeBeamer-Extensions-and-Addons/codebeamer-miro/issues`
 	);
 }
 

--- a/src/pages/import/components/settings/cardCustomization/appCardTagSettings.cy.tsx
+++ b/src/pages/import/components/settings/cardCustomization/appCardTagSettings.cy.tsx
@@ -39,7 +39,7 @@ describe('<AppCardTagSettings', () => {
 	});
 
 	context('apply button', () => {
-		it.only('shows an "Apply" button to apply the changes if there are imported items', () => {
+		it('shows an "Apply" button to apply the changes if there are imported items', () => {
 			const stubSync = cy.stub();
 
 			const itemOne: Partial<AppCard> = {
@@ -62,7 +62,7 @@ describe('<AppCardTagSettings', () => {
 			cy.getBySel('apply').should('exist');
 		});
 
-		it.only('doesnt show an "Apply" button if there are no imported items', () => {
+		it('doesnt show an "Apply" button if there are no imported items', () => {
 			cy.mountWithStore(<AppCardTagSettings />);
 
 			cy.getBySel('apply').should('not.exist');

--- a/src/pages/import/components/settings/cardCustomization/appCardTagSettings.cy.tsx
+++ b/src/pages/import/components/settings/cardCustomization/appCardTagSettings.cy.tsx
@@ -39,10 +39,33 @@ describe('<AppCardTagSettings', () => {
 	});
 
 	context('apply button', () => {
-		it('shows an "Apply" button to apply the changes to the config', () => {
+		it.only('shows an "Apply" button to apply the changes if there are imported items', () => {
+			const stubSync = cy.stub();
+
+			const itemOne: Partial<AppCard> = {
+				id: '1',
+				title: '[RETUS-1]',
+				sync: stubSync,
+			};
+			const itemTwo: Partial<AppCard> = {
+				id: '2',
+				title: '[RETUS-2]',
+				sync: stubSync,
+			};
+
+			const stubBoardGet = cy.stub(miro.board, 'get').callsFake(() => {
+				return Promise.resolve([itemOne, itemTwo]);
+			});
+
 			cy.mountWithStore(<AppCardTagSettings />);
 
 			cy.getBySel('apply').should('exist');
+		});
+
+		it.only('doesnt show an "Apply" button if there are no imported items', () => {
+			cy.mountWithStore(<AppCardTagSettings />);
+
+			cy.getBySel('apply').should('not.exist');
 		});
 
 		it('updates the imported cards when applying', { retries: 5 }, () => {


### PR DESCRIPTION
# Feature/Widget-metadata

Metadata has been added on the widget-level in SDK 2.  

## Changes

- Refactored `createCard` to set following Metadata:  

```ts
item: {
    id: number;
    tracker: {
      id: number 
   }
}
```

We currently only use the itemId in some cases. The structure of the `item` property is equal to that of a `CodeBeamerItem` you get from swagger- and legacy responses, so it should be easily extendable.

- Refactored `useImportedItems` & the `on('app_card:open')` handler to get the item's id from the metadata, if possible, with a fallback to how they got it previously - from the card's title.