### PR TITLE
Increase max number of Items that can be synched / updated

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"react-select": "^5.4.0"
 			},
 			"devDependencies": {
-				"@mirohq/websdk-types": "^2.5.0",
+				"@mirohq/websdk-types": "^2.8.0",
 				"@types/cypress": "^1.1.3",
 				"@types/react": "18.0.15",
 				"@types/react-dom": "18.0.6",
@@ -652,9 +652,9 @@
 			}
 		},
 		"node_modules/@mirohq/websdk-types": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@mirohq/websdk-types/-/websdk-types-2.5.0.tgz",
-			"integrity": "sha512-ejCKqBfIRDeQ98u9ISdMbo6c8Gk0+rVS0CkcsCOhy8xIQqmBezmHPAMa7DH5o++YdgeH4ZVpIuv8+FZBU/QMdw==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@mirohq/websdk-types/-/websdk-types-2.8.0.tgz",
+			"integrity": "sha512-MR7U3PowSwlYBd4ROvBNtLVQ30R1nku0pQGmv9MBsNXaZy7QALg94JZjM4eIyAiNQ5QwkU6d3QpcOSpjUa7QMQ==",
 			"dev": true,
 			"dependencies": {
 				"typescript": "4.6.3"
@@ -4595,9 +4595,9 @@
 			}
 		},
 		"@mirohq/websdk-types": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@mirohq/websdk-types/-/websdk-types-2.5.0.tgz",
-			"integrity": "sha512-ejCKqBfIRDeQ98u9ISdMbo6c8Gk0+rVS0CkcsCOhy8xIQqmBezmHPAMa7DH5o++YdgeH4ZVpIuv8+FZBU/QMdw==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@mirohq/websdk-types/-/websdk-types-2.8.0.tgz",
+			"integrity": "sha512-MR7U3PowSwlYBd4ROvBNtLVQ30R1nku0pQGmv9MBsNXaZy7QALg94JZjM4eIyAiNQ5QwkU6d3QpcOSpjUa7QMQ==",
 			"dev": true,
 			"requires": {
 				"typescript": "4.6.3"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 		"react-select": "^5.4.0"
 	},
 	"devDependencies": {
-		"@mirohq/websdk-types": "^2.5.0",
+		"@mirohq/websdk-types": "^2.8.0",
 		"@types/cypress": "^1.1.3",
 		"@types/react": "18.0.15",
 		"@types/react-dom": "18.0.6",

--- a/src/pages/import/components/updater/Updater.tsx
+++ b/src/pages/import/components/updater/Updater.tsx
@@ -8,7 +8,7 @@ import {
 import { updateAppCard } from '../../../../api/miro.api';
 import {
 	DEFAULT_RESULT_PAGE,
-	MAX_ITEMS_PER_IMPORT,
+	MAX_ITEMS_PER_SYNCH,
 } from '../../../../constants/cb-import-defaults';
 import { AppCardToItemMapping } from '../../../../models/appCardToItemMapping.if';
 import { CodeBeamerItem } from '../../../../models/codebeamer-item.if';
@@ -37,7 +37,7 @@ export default function Updater(props: {
 	//? maybe fetching every item on its own is more efficient. cb takes a long time to resolve that 'item.id IN' query.
 	const { data, error, isLoading } = useGetItemsQuery({
 		page: DEFAULT_RESULT_PAGE,
-		pageSize: MAX_ITEMS_PER_IMPORT,
+		pageSize: MAX_ITEMS_PER_SYNCH,
 		queryString: `item.id IN (${props.items
 			.map((i) => i.itemId)
 			.join(',')})`,


### PR DESCRIPTION
### Changes

- Increase the maximum number of Items that can be synched / updated to 500, as was originally intended.  
The number is still arbitrary and a proper system to handling larger ones has yet to be put in place.  
- Updates Miro Sdk Types to 2.8.0, removing some compiler complaints for lacking types

### Issues 

Closes #98 