### PR TITLE
Add tooltips on Import page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,44 +1,44 @@
 {
-  "author": "urecha",
-  "name": "codebeamer-cards",
-  "version": "1.4.0",
-  "licence": "AGPL-3.0",
-  "description": "This is a codeBeamer <-> Miro integration web-plugin to be installed on Miro.\r It allows to import codeBeamer items to a Miro board, displaying any associations between the items.",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/codeBeamer-Extensions-and-Addons/codebeamer-miro.git"
-  },
-  "bugs": {
-    "url": "https://github.com/codeBeamer-Extensions-and-Addons/codebeamer-miro/issues"
-  },
-  "homepage": "https://github.com/codeBeamer-Extensions-and-Addons/codebeamer-miro#readme",
-  "scripts": {
-    "start": "vite",
-    "build": "vite build",
-    "serve": "vite preview",
-    "test": "cypress run -b chrome --component --record false",
-    "test:open": "cypress open --component -b chrome"
-  },
-  "dependencies": {
-    "@reduxjs/toolkit": "^1.8.3",
-    "formik": "^2.2.9",
-    "html-entities": "^2.3.3",
-    "mirotone": "^4.2.0",
-    "react": "18.2.0",
-    "react-bootstrap": "^2.5.0",
-    "react-dom": "18.2.0",
-    "react-redux": "^8.0.2",
-    "react-select": "^5.4.0",
-    "react-tooltip": "^5.11.1"
-  },
-  "devDependencies": {
-    "@mirohq/websdk-types": "^2.8.0",
-    "@types/cypress": "^1.1.3",
-    "@types/react": "18.0.15",
-    "@types/react-dom": "18.0.6",
-    "@vitejs/plugin-react-refresh": "1.3.6",
-    "cypress": "^11.2.0",
-    "typescript": "4.7.4",
-    "vite": "^3.2.5"
-  }
+	"author": "urecha",
+	"name": "codebeamer-cards",
+	"version": "1.4.0",
+	"licence": "AGPL-3.0",
+	"description": "This is a codeBeamer <-> Miro integration web-plugin to be installed on Miro.\r It allows to import codeBeamer items to a Miro board, displaying any associations between the items.",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/codeBeamer-Extensions-and-Addons/codebeamer-miro.git"
+	},
+	"bugs": {
+		"url": "https://github.com/codeBeamer-Extensions-and-Addons/codebeamer-miro/issues"
+	},
+	"homepage": "https://github.com/codeBeamer-Extensions-and-Addons/codebeamer-miro#readme",
+	"scripts": {
+		"start": "vite",
+		"build": "vite build",
+		"serve": "vite preview",
+		"test": "cypress run -b electron --component --record false",
+		"test:open": "cypress open --component -b electron"
+	},
+	"dependencies": {
+		"@reduxjs/toolkit": "^1.8.3",
+		"formik": "^2.2.9",
+		"html-entities": "^2.3.3",
+		"mirotone": "^4.2.0",
+		"react": "18.2.0",
+		"react-bootstrap": "^2.5.0",
+		"react-dom": "18.2.0",
+		"react-redux": "^8.0.2",
+		"react-select": "^5.4.0",
+		"react-tooltip": "^5.11.1"
+	},
+	"devDependencies": {
+		"@mirohq/websdk-types": "^2.8.0",
+		"@types/cypress": "^1.1.3",
+		"@types/react": "18.0.15",
+		"@types/react-dom": "18.0.6",
+		"@vitejs/plugin-react-refresh": "1.3.6",
+		"cypress": "^11.2.0",
+		"typescript": "4.7.4",
+		"vite": "^3.2.5"
+	}
 }

--- a/src/pages/import/components/importHeader/ImportHeader.tsx
+++ b/src/pages/import/components/importHeader/ImportHeader.tsx
@@ -7,6 +7,9 @@ import {
 import { RootState } from '../../../../store/store';
 import Settings from '../settings/Settings';
 
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Tooltip from 'react-bootstrap/Tooltip';
+
 import './importHeader.css';
 
 export default function ImportHeader() {
@@ -47,76 +50,97 @@ export default function ImportHeader() {
 					codebeamer cards
 				</div>
 				<div className="actions flex flex-">
-					<button
-						className={`mx-1 
-						${
-							advancedSearch
-								? 'button-icon-small button-icon button-icon-secondary icon-parameters'
-								: 'button button-secondary button-small'
-						}`}
-						onClick={toggleSearchMethod}
-						title={
-							advancedSearch
-								? 'Query assistant'
-								: 'CBQL-String Input'
+					<DefaultOverlayTrigger
+						content={
+							advancedSearch ? 'Assisted Query' : 'CBQL Input'
 						}
-						data-test="search-method"
 					>
-						{advancedSearch ? (
-							''
-						) : (
-							<i data-test="cbql-icon">
-								<svg
-									width="24"
-									height="24"
-									viewBox="0 0 28 28"
-									fill="none"
-									xmlns="http://www.w3.org/2000/svg"
-								>
-									<text fill="#000000">
-										<tspan x="4" y="13" textLength="20">
-											CB
-										</tspan>
-										<tspan x="4" y="25">
-											QL
-										</tspan>
-									</text>
-								</svg>
-							</i>
-						)}
-					</button>
-					<button
-						className="button button-secondary button-small mx-1"
-						onClick={openSettingsModal}
-					>
-						<svg
-							xmlns="http://www.w3.org/2000/svg"
-							className="ionIcon pos-adjusted-up"
-							viewBox="0 0 512 512"
+						<button
+							className={`mx-1 
+							${
+								advancedSearch
+									? 'button-icon-small button-icon button-icon-secondary icon-parameters'
+									: 'button button-secondary button-small'
+							}`}
+							onClick={toggleSearchMethod}
+							data-test="search-method"
 						>
-							<title>Settings</title>
-							<path
-								d="M262.29 192.31a64 64 0 1057.4 57.4 64.13 64.13 0 00-57.4-57.4zM416.39 256a154.34 154.34 0 01-1.53 20.79l45.21 35.46a10.81 10.81 0 012.45 13.75l-42.77 74a10.81 10.81 0 01-13.14 4.59l-44.9-18.08a16.11 16.11 0 00-15.17 1.75A164.48 164.48 0 01325 400.8a15.94 15.94 0 00-8.82 12.14l-6.73 47.89a11.08 11.08 0 01-10.68 9.17h-85.54a11.11 11.11 0 01-10.69-8.87l-6.72-47.82a16.07 16.07 0 00-9-12.22 155.3 155.3 0 01-21.46-12.57 16 16 0 00-15.11-1.71l-44.89 18.07a10.81 10.81 0 01-13.14-4.58l-42.77-74a10.8 10.8 0 012.45-13.75l38.21-30a16.05 16.05 0 006-14.08c-.36-4.17-.58-8.33-.58-12.5s.21-8.27.58-12.35a16 16 0 00-6.07-13.94l-38.19-30A10.81 10.81 0 0149.48 186l42.77-74a10.81 10.81 0 0113.14-4.59l44.9 18.08a16.11 16.11 0 0015.17-1.75A164.48 164.48 0 01187 111.2a15.94 15.94 0 008.82-12.14l6.73-47.89A11.08 11.08 0 01213.23 42h85.54a11.11 11.11 0 0110.69 8.87l6.72 47.82a16.07 16.07 0 009 12.22 155.3 155.3 0 0121.46 12.57 16 16 0 0015.11 1.71l44.89-18.07a10.81 10.81 0 0113.14 4.58l42.77 74a10.8 10.8 0 01-2.45 13.75l-38.21 30a16.05 16.05 0 00-6.05 14.08c.33 4.14.55 8.3.55 12.47z"
-								fill="none"
-								stroke="currentColor"
-								strokeLinecap="round"
-								strokeLinejoin="round"
-								strokeWidth="32"
-							/>
-						</svg>
-					</button>
-					<button
-						className="button-secondary button-small button mx-1"
-						onClick={() => dispatch(setShowAnnouncements(true))}
-						title="Latest update informations (version 1.1)"
-					>
-						<span className="icon icon-bell clickable"></span>
-					</button>
+							{advancedSearch ? (
+								''
+							) : (
+								<i data-test="cbql-icon">
+									<svg
+										width="24"
+										height="24"
+										viewBox="0 0 28 28"
+										fill="none"
+										xmlns="http://www.w3.org/2000/svg"
+									>
+										<text fill="#000000">
+											<tspan x="4" y="13" textLength="20">
+												CB
+											</tspan>
+											<tspan x="4" y="25">
+												QL
+											</tspan>
+										</text>
+									</svg>
+								</i>
+							)}
+						</button>
+					</DefaultOverlayTrigger>
+					<DefaultOverlayTrigger content="Settings">
+						<button
+							className="button button-secondary button-small mx-1"
+							onClick={openSettingsModal}
+						>
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								className="ionIcon pos-adjusted-up"
+								viewBox="0 0 512 512"
+							>
+								<path
+									d="M262.29 192.31a64 64 0 1057.4 57.4 64.13 64.13 0 00-57.4-57.4zM416.39 256a154.34 154.34 0 01-1.53 20.79l45.21 35.46a10.81 10.81 0 012.45 13.75l-42.77 74a10.81 10.81 0 01-13.14 4.59l-44.9-18.08a16.11 16.11 0 00-15.17 1.75A164.48 164.48 0 01325 400.8a15.94 15.94 0 00-8.82 12.14l-6.73 47.89a11.08 11.08 0 01-10.68 9.17h-85.54a11.11 11.11 0 01-10.69-8.87l-6.72-47.82a16.07 16.07 0 00-9-12.22 155.3 155.3 0 01-21.46-12.57 16 16 0 00-15.11-1.71l-44.89 18.07a10.81 10.81 0 01-13.14-4.58l-42.77-74a10.8 10.8 0 012.45-13.75l38.21-30a16.05 16.05 0 006-14.08c-.36-4.17-.58-8.33-.58-12.5s.21-8.27.58-12.35a16 16 0 00-6.07-13.94l-38.19-30A10.81 10.81 0 0149.48 186l42.77-74a10.81 10.81 0 0113.14-4.59l44.9 18.08a16.11 16.11 0 0015.17-1.75A164.48 164.48 0 01187 111.2a15.94 15.94 0 008.82-12.14l6.73-47.89A11.08 11.08 0 01213.23 42h85.54a11.11 11.11 0 0110.69 8.87l6.72 47.82a16.07 16.07 0 009 12.22 155.3 155.3 0 0121.46 12.57 16 16 0 0015.11 1.71l44.89-18.07a10.81 10.81 0 0113.14 4.58l42.77 74a10.8 10.8 0 01-2.45 13.75l-38.21 30a16.05 16.05 0 00-6.05 14.08c.33 4.14.55 8.3.55 12.47z"
+									fill="none"
+									stroke="currentColor"
+									strokeLinecap="round"
+									strokeLinejoin="round"
+									strokeWidth="32"
+								/>
+							</svg>
+						</button>
+					</DefaultOverlayTrigger>
+					<DefaultOverlayTrigger content="Latest update informations">
+						<button
+							className="button-secondary button-small button mx-1"
+							onClick={() => dispatch(setShowAnnouncements(true))}
+						>
+							<span className="icon icon-bell clickable"></span>
+						</button>
+					</DefaultOverlayTrigger>
 				</div>
 			</header>
 			{showSettings && (
 				<Settings onClose={() => setShowSettings(false)} />
 			)}
 		</>
+	);
+}
+
+function DefaultOverlayTrigger(props: {
+	children: JSX.Element;
+	content: string;
+}): JSX.Element {
+	return (
+		<OverlayTrigger
+			placement="bottom"
+			trigger={['hover', 'focus']}
+			delay={{ show: 250, hide: 250 }}
+			overlay={
+				<Tooltip className="tooltip-grey">{props.content}</Tooltip>
+			}
+		>
+			{props.children}
+		</OverlayTrigger>
 	);
 }

--- a/src/pages/import/components/importHeader/importHeader.css
+++ b/src/pages/import/components/importHeader/importHeader.css
@@ -6,3 +6,7 @@ header {
 	width: 40px;
 	height: 40px;
 }
+
+.tooltip-grey {
+	--bs-tooltip-bg: var(--indigo700) !important;
+}


### PR DESCRIPTION
# Tooltips on Import page

![image](https://github.com/codeBeamer-Extensions-and-Addons/codebeamer-miro/assets/70019423/6990a615-da2e-4319-b7cc-71e0dfd409d3)

Updated the buttons that can benefit of a tooltip and previously used `title` attributes to convey their meaning to use the tooltip implementation pioneered on the `ItemActions` component's children.  
Differs slightly in implementation since the three buttons are in the same component here (which could be refactored too..), and also colored them in `indigo700` as opposed to `blue700`, since the latter is essentially "primary" and tooltips probably shouldn't be primarily colored, but secondarily (?).  

## Changes

- `package.json` set `electron` as default browser for cypress scripts
- `ImportHeader.tsx/css` added Tooltips & styling