### PR TITLE
Display association description if present

### DIFF
--- a/src/models/api-query-types.ts
+++ b/src/models/api-query-types.ts
@@ -1,30 +1,30 @@
-import { AppData } from "@mirohq/websdk-types";
-import { RelationshipType } from "../enums/associationRelationshipType.enum";
+import { AppData } from '@mirohq/websdk-types';
+import { RelationshipType } from '../enums/associationRelationshipType.enum';
 
 export interface ItemQueryPage {
-  page: number;
-  pageSize: number;
-  total: number;
-  items: any[];
+	page: number;
+	pageSize: number;
+	total: number;
+	items: any[];
 }
 
 export interface TrackerSearchPage {
-  page: number;
-  pageSize: number;
-  total: number;
-  trackers: any[];
+	page: number;
+	pageSize: number;
+	total: number;
+	trackers: any[];
 }
 
 export interface UserQueryPage {
-  page: number;
-  pageSize: number;
-  total: number;
-  users: {
-    name: string;
-    firstName: string;
-    lastName: string;
-    email: string;
-  }[];
+	page: number;
+	pageSize: number;
+	total: number;
+	users: {
+		name: string;
+		firstName: string;
+		lastName: string;
+		email: string;
+	}[];
 }
 
 /**
@@ -32,8 +32,8 @@ export interface UserQueryPage {
  * fields the item has and which are currently editable or readonly.
  */
 export interface CodeBeamerItemFields {
-  editableFields: CodeBeamerItemField[];
-  readonlyFields: CodeBeamerItemField[];
+	editableFields: CodeBeamerItemField[];
+	readonlyFields: CodeBeamerItemField[];
 }
 
 /**
@@ -41,35 +41,35 @@ export interface CodeBeamerItemFields {
  * specifying a specific field's values.
  */
 export interface CodeBeamerItemField {
-  fieldId: number;
-  name: string;
-  values: FieldOptions[];
-  type: string;
+	fieldId: number;
+	name: string;
+	values: FieldOptions[];
+	type: string;
 }
 
 /**
  * Structure of options and minimal information needed to update an item's field with the /Fields endpoint
  */
 export interface FieldOptions {
-  id: number;
-  uri?: string;
-  name: string;
-  type?: string;
+	id: number;
+	uri?: string;
+	name: string;
+	type?: string;
 }
 
 /**
  * Structure of a response from the /api/v3/items/{id}/relations endpoint
  */
 export interface RelationsQuery {
-  itemId: {
-    id: number;
-    version?: number;
-  };
+	itemId: {
+		id: number;
+		version?: number;
+	};
 
-  downstreamReferences: ItemRelation[];
-  upstreamReferences: ItemRelation[];
-  outgoingAssociations: ItemRelation[];
-  incomingAssociations: ItemRelation[];
+	downstreamReferences: ItemRelation[];
+	upstreamReferences: ItemRelation[];
+	outgoingAssociations: ItemRelation[];
+	incomingAssociations: ItemRelation[];
 }
 
 /**
@@ -77,27 +77,40 @@ export interface RelationsQuery {
  * the item it goes to
  */
 export interface ItemRelation {
-  id: number;
-  itemRevision: {
-    id: number;
-    version?: number;
-  };
-  type: string;
+	id: number;
+	itemRevision: {
+		id: number;
+		version?: number;
+	};
+	type: string;
 }
 
 /**
  * Structure of an Association
  */
 export interface Association {
-  associationId: number;
-  targetItemId: number;
+	associationId: number;
+	targetItemId: number;
+}
+
+export interface AssociationDetails {
+	id: number;
+	description: string;
+	type: CodeBeamerEntityReference;
+	from: CodeBeamerEntityReference;
+	to: CodeBeamerEntityReference;
+}
+
+interface CodeBeamerEntityReference {
+	id: number;
+	name: string;
 }
 
 /**
  * Structure of an Items metadata
  */
 export interface ItemMetadata {
-  id: string;
-  metadata: AppData;
-  type: string;
+	id: string;
+	metadata: AppData;
+	type: string;
 }


### PR DESCRIPTION
## Summary

_Associations_ can have a short text description, explaining it more than just the association's type / name.  
If this is present, it should be visualized instead of the type / name.  

![image](https://github.com/codeBeamer-Extensions-and-Addons/codebeamer-miro/assets/70019423/9d628511-7e3d-4933-a95d-a1fb5374105a)

## Changes

- `miro.api.ts`  
  - Refactor connector-creation methods slightly.  
  - Change calculation of `connectorCaptions` to implement above described logic.
- `api-query-types.ts`  
  - Add `AssociationDetails` interface
  - Add `CodeBeamerEntityReference` generic interface
