### PR TITLE
Lucid export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ docs/
 
 # cypress large files and env variables
 cypress/screenshots
+cypress/downloads
 cypress/videos
 cypress.env.json
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### [1.6]
+
+-   Add "Lucid export" functionality  
+    Allows exporting what items there are cards for and where on the board, which can then be imported with [codebeamer-cards for Lucid](https://github.com/codeBeamer-Extensions-and-Addons/codebeamer-lucidspark/wiki/Migrate-from-Miro)
+
 ## Released
 
 ### [1.5.2]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
 	"name": "codebeamer-cards",
-	"version": "1.4.0",
+	"version": "1.5.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "codebeamer-cards",
-			"version": "1.4.0",
+			"version": "1.5.2",
 			"dependencies": {
 				"@reduxjs/toolkit": "^1.8.3",
+				"file-saver": "^2.0.5",
 				"formik": "^2.2.9",
 				"html-entities": "^2.3.3",
 				"mirotone": "^4.2.0",
@@ -22,6 +23,7 @@
 			"devDependencies": {
 				"@mirohq/websdk-types": "^2.8.0",
 				"@types/cypress": "^1.1.3",
+				"@types/file-saver": "^2.0.5",
 				"@types/react": "18.0.15",
 				"@types/react-dom": "18.0.6",
 				"@vitejs/plugin-react-refresh": "1.3.6",
@@ -819,6 +821,12 @@
 			"dependencies": {
 				"cypress": "*"
 			}
+		},
+		"node_modules/@types/file-saver": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@types/file-saver/-/file-saver-2.0.5.tgz",
+			"integrity": "sha512-zv9kNf3keYegP5oThGLaPk8E081DFDuwfqjtiTzm6PoxChdJ1raSuADf2YGCVIyrSynLrgc8JWv296s7Q7pQSQ==",
+			"dev": true
 		},
 		"node_modules/@types/hoist-non-react-statics": {
 			"version": "3.3.1",
@@ -2181,6 +2189,11 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/file-saver": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+			"integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
 		},
 		"node_modules/find-root": {
 			"version": "1.1.0",
@@ -4721,6 +4734,12 @@
 				"cypress": "*"
 			}
 		},
+		"@types/file-saver": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@types/file-saver/-/file-saver-2.0.5.tgz",
+			"integrity": "sha512-zv9kNf3keYegP5oThGLaPk8E081DFDuwfqjtiTzm6PoxChdJ1raSuADf2YGCVIyrSynLrgc8JWv296s7Q7pQSQ==",
+			"dev": true
+		},
 		"@types/hoist-non-react-statics": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
@@ -5648,6 +5667,11 @@
 			"requires": {
 				"escape-string-regexp": "^1.0.5"
 			}
+		},
+		"file-saver": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+			"integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
 		},
 		"find-root": {
 			"version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 	},
 	"dependencies": {
 		"@reduxjs/toolkit": "^1.8.3",
+		"file-saver": "^2.0.5",
 		"formik": "^2.2.9",
 		"html-entities": "^2.3.3",
 		"mirotone": "^4.2.0",
@@ -34,6 +35,7 @@
 	"devDependencies": {
 		"@mirohq/websdk-types": "^2.8.0",
 		"@types/cypress": "^1.1.3",
+		"@types/file-saver": "^2.0.5",
 		"@types/react": "18.0.15",
 		"@types/react-dom": "18.0.6",
 		"@vitejs/plugin-react-refresh": "1.3.6",

--- a/src/hooks/useImportedItems.ts
+++ b/src/hooks/useImportedItems.ts
@@ -47,7 +47,7 @@ export const useImportedItems = () => {
 						itemId = itemKey[1];
 					}
 
-					return { appCardId: card.id, itemId: itemId };
+					return { appCardId: card.id, itemId: itemId, coordinates: { x: card.x, y: card.y } };
 				})
 			);
 			setImportedItems(importedItems);

--- a/src/models/appCardToItemMapping.if.ts
+++ b/src/models/appCardToItemMapping.if.ts
@@ -4,4 +4,5 @@
 export interface AppCardToItemMapping {
 	appCardId: string;
 	itemId: string;
+	coordinates?: { x: number, y: number };
 }

--- a/src/pages/import/components/settings/Settings.tsx
+++ b/src/pages/import/components/settings/Settings.tsx
@@ -6,6 +6,7 @@ import ProjectSelection from '../projectSelection/ProjectSelection';
 import AppCardTagSettings from './cardCustomization/AppCardTagSettings';
 
 import './settings.css';
+import LucidExport from './lucidExport/LucidExport';
 
 /**
  * Wrapper for the various available settings, which it displays in a Modal.
@@ -27,6 +28,10 @@ export default function Settings(props: { onClose: Function }) {
 			// icon: 'plug',
 			tab: <AuthForm headerLess={true} successAnimation={true} />,
 		},
+		{
+			title: 'Lucid Export',
+			tab: <LucidExport/>
+		}
 	];
 
 	return (

--- a/src/pages/import/components/settings/lucidExport/LucidExport.cy.tsx
+++ b/src/pages/import/components/settings/lucidExport/LucidExport.cy.tsx
@@ -1,0 +1,41 @@
+import { AppCard } from '@mirohq/websdk-types';
+import React from 'react';
+import LucidExport from './LucidExport';
+
+describe('<LucidExport', () => {
+	it('mounts', () => {
+		cy.mountWithStore(<LucidExport />);
+	});
+
+    it('has a button to load all items on the board', () => {
+        cy.mountWithStore(<LucidExport />);
+        cy.get('button').contains('Export');
+    });
+
+    describe('button logic', () => {
+        it('loads all items on the board on click', () => {
+            const stubSync = cy.stub();
+
+            const itemOne: Partial<AppCard> = {
+				id: '1',
+				title: '[RETUS-1]',
+				sync: stubSync,
+			};
+			const itemTwo: Partial<AppCard> = {
+				id: '2',
+				title: '[RETUS-2]',
+				sync: stubSync,
+			};
+
+            const stubBoardGet = cy.stub(miro.board, 'get').callsFake(() => {
+				return Promise.resolve([itemOne, itemTwo]);
+			});
+
+            cy.mountWithStore(<LucidExport />);
+            cy.get('button').contains('Generate').click().then(() => {
+                expect(stubBoardGet).to.have.been.called;
+            })
+        });
+    })
+});
+

--- a/src/pages/import/components/settings/lucidExport/LucidExport.cy.tsx
+++ b/src/pages/import/components/settings/lucidExport/LucidExport.cy.tsx
@@ -36,6 +36,44 @@ describe('<LucidExport', () => {
                 expect(stubBoardGet).to.have.been.called;
             })
         });
+
+        it('downloads a json file on click', () => {
+            const stubSync = cy.stub();
+
+            const itemOne: Partial<AppCard> = {
+                id: '1',
+                x: 1,
+                y: 2,
+                title: '[RETUS-1]',
+                sync: stubSync,
+            };
+            const itemTwo: Partial<AppCard> = {
+				id: '2',
+				x: 2,
+				y: 1,
+				title: '[RETUS-2]',
+				sync: stubSync,
+			};
+            cy.stub(miro.board, 'get').callsFake(() => {
+				return Promise.resolve([itemOne, itemTwo]);
+			});
+
+            cy.mountWithStore(<LucidExport />);
+            cy.get('button').contains('Export').click().then(() => {
+                cy.wait(100);
+                //file should be downloaded into cypress/downloads
+                cy.readFile(
+					`cypress/downloads/miro-export-${new Date()
+						.toISOString()
+						.substring(0, 10)}.json`
+				).then((file) => {
+					expect(file).to.deep.equal([
+                        { id: itemOne.id, coordinates: { x: itemOne.x, y: itemOne.y } },
+                        { id: itemTwo.id, coordinates: { x: itemTwo.x, y: itemTwo.y } },
+                    ]);
+				});
+            });
+        });
     })
 });
 

--- a/src/pages/import/components/settings/lucidExport/LucidExport.cy.tsx
+++ b/src/pages/import/components/settings/lucidExport/LucidExport.cy.tsx
@@ -32,7 +32,7 @@ describe('<LucidExport', () => {
 			});
 
             cy.mountWithStore(<LucidExport />);
-            cy.get('button').contains('Generate').click().then(() => {
+            cy.get('button').contains('Export').click().then(() => {
                 expect(stubBoardGet).to.have.been.called;
             })
         });

--- a/src/pages/import/components/settings/lucidExport/LucidExport.tsx
+++ b/src/pages/import/components/settings/lucidExport/LucidExport.tsx
@@ -1,0 +1,117 @@
+import React, { useState } from 'react';
+import { useImportedItems } from '../../../../../hooks/useImportedItems';
+
+import FileSaver from 'file-saver';
+
+interface CompressedItem {
+	id: string;
+	coordinates: {
+		x: number;
+		y: number;
+	};
+}
+
+export default function LucidExport() {
+	const importedItems = useImportedItems();
+
+	const [isLoading, setIsLoading] = useState(false);
+	const [animateSuccess, setAnimateSuccess] = useState(false);
+	const [exported, setExported] = useState(false);
+
+	const showSuccessAnimation = () => {
+		setAnimateSuccess(true);
+		setTimeout(() => {
+			setAnimateSuccess(false);
+		}, 3500);
+	};
+
+	const generateLucidExportJSON = () => {
+		if (!importedItems?.length) {
+			console.warn('No codebeamer-cards found on the board');
+			return;
+		}
+
+		setIsLoading(true);
+
+		const compressedItems = importedItems.map((i) => {
+			return {
+				id: i.itemId,
+				coordinates: {
+					x: i.coordinates?.x ?? 0,
+					y: i.coordinates?.y ?? 0,
+				},
+			};
+		});
+
+		console.log(compressedItems);
+
+		const blob = new Blob([JSON.stringify(compressedItems)], {
+			type: 'application/json',
+		});
+		FileSaver.saveAs(blob, 'miro-export.json', { autoBom: false });
+		showSuccessAnimation();
+		setIsLoading(false);
+		setExported(true);
+	};
+
+	return (
+		<div className="centered">
+			{!animateSuccess && (
+				<button
+					onClick={generateLucidExportJSON}
+					disabled={isLoading}
+					className={`mt-3 fade-in button button-primary ${
+						isLoading ? 'button-loading' : ''
+					}`}
+					data-test="submit"
+				>
+					Export
+				</button>
+			)}
+			{animateSuccess && (
+				<span>
+					<svg
+						className="checkmark"
+						xmlns="http://www.w3.org/2000/svg"
+						viewBox="0 0 52 52"
+					>
+						<circle
+							className="checkmark__circle"
+							cx="26"
+							cy="26"
+							r="25"
+							fill="none"
+						/>
+						<path
+							className="checkmark__check"
+							fill="none"
+							d="M14.1 27.2l7.1 7.2 16.7-16.8"
+						/>
+					</svg>
+				</span>
+			)}
+			<p className="mt-3" style={{ width: '150%', textAlign: 'center' }}>
+				{exported ? (
+					<span className="fade-in">
+						Thanks for using codebeamer-cards for Miro! <br />
+						We hope you'll enjoy using{' '}
+						<a href="https://github.com/codeBeamer-Extensions-and-Addons/codebeamer-lucidspark/wiki">
+							codebeamer-cards for Lucidspark
+						</a>{' '}
+						as well.
+					</span>
+				) : (
+					<span>
+						Want to migrate your imported cards from Miro to
+						Lucidspark? Click the above button to generate a{' '}
+						<em>json</em> file that you can then import with{' '}
+						<a href="https://github.com/codeBeamer-Extensions-and-Addons/codebeamer-lucidspark/wiki">
+							codebeamer-cards for Lucidspark
+						</a>
+						.
+					</span>
+				)}
+			</p>
+		</div>
+	);
+}

--- a/src/pages/import/components/settings/lucidExport/LucidExport.tsx
+++ b/src/pages/import/components/settings/lucidExport/LucidExport.tsx
@@ -48,7 +48,7 @@ export default function LucidExport() {
 		const blob = new Blob([JSON.stringify(compressedItems)], {
 			type: 'application/json',
 		});
-        FileSaver.saveAs(blob, `miro-export-(${new Date().toISOString()}).json`, { autoBom: false });
+        FileSaver.saveAs(blob, `miro-export-${new Date().toISOString()}.json`, { autoBom: false });
 
 		showSuccessAnimation();
 		setIsLoading(false);

--- a/src/pages/import/components/settings/lucidExport/LucidExport.tsx
+++ b/src/pages/import/components/settings/lucidExport/LucidExport.tsx
@@ -43,12 +43,10 @@ export default function LucidExport() {
 			};
 		});
 
-		console.log(compressedItems);
-
 		const blob = new Blob([JSON.stringify(compressedItems)], {
 			type: 'application/json',
 		});
-        FileSaver.saveAs(blob, `miro-export-${new Date().toISOString()}.json`, { autoBom: false });
+        FileSaver.saveAs(blob, `miro-export-${new Date().toISOString().substring(0,10)}.json`, { autoBom: false });
 
 		showSuccessAnimation();
 		setIsLoading(false);

--- a/src/pages/import/components/settings/lucidExport/LucidExport.tsx
+++ b/src/pages/import/components/settings/lucidExport/LucidExport.tsx
@@ -48,7 +48,8 @@ export default function LucidExport() {
 		const blob = new Blob([JSON.stringify(compressedItems)], {
 			type: 'application/json',
 		});
-		FileSaver.saveAs(blob, 'miro-export.json', { autoBom: false });
+        FileSaver.saveAs(blob, `miro-export-(${new Date().toISOString()}).json`, { autoBom: false });
+
 		showSuccessAnimation();
 		setIsLoading(false);
 		setExported(true);


### PR DESCRIPTION
## Summary

Implement a little tool that generates a `JSON` file, which can then be used with [codebeamer-cards for Lucidspark](https://github.com/codeBeamer-Extensions-and-Addons/codebeamer-lucidspark) to essentially migrate cards, with the benefit of getting all cards that currently were on the miro board in question at the same place on the respective lucid board (coordinates are retained).

![miro_export](https://github.com/codeBeamer-Extensions-and-Addons/codebeamer-miro/assets/70019423/b55c5635-16bb-41e6-9a92-73ffa536dad0)

See the entire guide on [cb-cards for lucidspark's wiki](https://github.com/codeBeamer-Extensions-and-Addons/codebeamer-lucidspark/wiki/Migrate-from-Miro)

## Changes

### Added

- `LucidExport.tsx`  
 Component that implements the above described

### Changed

- `useImportedItems` hook
 Added coordinates to the returned data.
- `Settings.tsx`  
 Add tab where `<LucidExport/>` is rendered