### PR TITLE
1.6.1 Hotfix/vite basepath

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 		<link rel="stylesheet" href="/src/assets/style.css" />
 		<link rel="stylesheet" href="/index.css" />
 		<script src="https://miro.com/app/static/sdk/v2/miro.js"></script>
-		<title>CB-Miro v1.6.0</title>
+		<title>CB-Miro v1.6.1</title>
 	</head>
 	<body>
 		<div class="grid container">
@@ -25,7 +25,7 @@
 			</div>
 			<div class="cs1 ce12">
 				<h1>
-					CodeBeamer / Miro Integration Plugin v1.6.0<br /><small
+					CodeBeamer / Miro Integration Plugin v1.6.1<br /><small
 						class="muted"
 						>by
 						<a href="https://github.com/urecha">urecha</a>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"author": "urecha",
 	"name": "codebeamer-cards",
-	"version": "1.6.0",
+	"version": "1.6.1",
 	"licence": "AGPL-3.0",
 	"description": "This is a codeBeamer <-> Miro integration web-plugin to be installed on Miro.\r It allows to import codeBeamer items to a Miro board, displaying any associations between the items.",
 	"repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ async function init() {
 	});
 
 	console.info(
-		`[codeBeamer-cards] Plugin v1.6.0 initialized. Experiencing issues? Let us know at https://github.com/codeBeamer-Extensions-and-Addons/codebeamer-miro/issues`
+		`[codeBeamer-cards] Plugin v1.6.1 initialized. Experiencing issues? Let us know at https://github.com/codeBeamer-Extensions-and-Addons/codebeamer-miro/issues`
 	);
 }
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -19,14 +19,15 @@ const allHtmlEntries = fs
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  build: {
-    rollupOptions: {
-      input: allHtmlEntries,
-    },
-  },
-  plugins: [reactRefresh()],
-  server: {
-    host: "127.0.0.1",
-    port: 3000,
-  },
+	build: {
+		rollupOptions: {
+			input: allHtmlEntries,
+		},
+	},
+	base: '/codebeamer-miro/',
+	plugins: [reactRefresh()],
+	server: {
+		host: '127.0.0.1',
+		port: 3000,
+	},
 });


### PR DESCRIPTION
Mistakenly included `vite.config.js` in last release's commits, overwriting the base path, breaking the plugin.

Adds `base: '/codebeamer-miro/'` back in.